### PR TITLE
[F-029] MovingObstacle 관련 버그 해결

### DIFF
--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -19,6 +19,7 @@ public abstract class CharacterBase : MonoBehaviour
     public float curRotSpeed { get; set; }
 
     public Vector3 pushDirection = Vector3.zero; // to check if being pushed
+    public float pushSpeed = 0;
     private const float BLOCK_SIZE = 2.0f;
 
     // State management
@@ -126,6 +127,7 @@ public abstract class CharacterBase : MonoBehaviour
         if (curTurnAngle != 0.0f)
         {
             listCurTurn = listTurn;
+            targetTranslation = playerCurPos; // staying at the previous grid
             StartAction();
         }
     }
@@ -150,6 +152,7 @@ public abstract class CharacterBase : MonoBehaviour
                         if (lever.canToggleDirection == targetDirection)
                         {
                             lever.doPushLever = true;
+                            targetTranslation = playerCurPos; // because stuck at the wall
                             ChooseAndStartAction(listStay, listTurn);
                         }
                         else

--- a/Chronus/Assets/Scripts/Character/CharacterHop.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterHop.cs
@@ -51,15 +51,16 @@ public class CharacterHop : MonoBehaviour, IState<CharacterBase>
         float hopStep = _CharacterBase.curHopSpeed * Time.deltaTime;
         _CharacterBase.transform.Translate(Vector3.up * _CharacterBase.curHopDir * hopStep);
 
-        float moveStep = _CharacterBase.curSpeed * Time.deltaTime;
         if (_CharacterBase.pushDirection != Vector3.zero)
         {
+            float moveStep = _CharacterBase.pushSpeed * Time.deltaTime;
             Vector3 currentTranslation = _CharacterBase.transform.position;
             Vector3 direction = (targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(2f * direction * moveStep, Space.World);
         }
         else
-        {
+        {   
+            float moveStep = _CharacterBase.curSpeed * Time.deltaTime;
             _CharacterBase.transform.Translate(Vector3.forward * moveStep);
         }
 
@@ -84,8 +85,9 @@ public class CharacterHop : MonoBehaviour, IState<CharacterBase>
         {
             _CharacterBase.transform.position = targetTranslation;
             _CharacterBase.playerCurPos = _CharacterBase.transform.position;
-            _CharacterBase.doneAction = true;
             _CharacterBase.pushDirection = Vector3.zero;
+            _CharacterBase.pushSpeed = 0;
+            _CharacterBase.doneAction = true;
         }
     }
 }

--- a/Chronus/Assets/Scripts/Character/CharacterIdle.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterIdle.cs
@@ -29,7 +29,7 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
         if (_CharacterBase.pushDirection != Vector3.zero)
         {
             targetTranslation = _CharacterBase.targetTranslation;
-            float moveStep = _CharacterBase.moveSpeedHor * Time.deltaTime;
+            float moveStep = _CharacterBase.pushSpeed * Time.deltaTime;
             Vector3 currentTranslation = _CharacterBase.transform.position;
             Vector3 direction = (targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(direction * moveStep, Space.World);
@@ -46,8 +46,9 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
             {
                 _CharacterBase.transform.position = targetTranslation;
                 _CharacterBase.playerCurPos = _CharacterBase.transform.position;
-                _CharacterBase.doneAction = true;
                 _CharacterBase.pushDirection = Vector3.zero;
+                _CharacterBase.pushSpeed = 0;
+                _CharacterBase.doneAction = true;
             }
         }
         else

--- a/Chronus/Assets/Scripts/Character/CharacterMove.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterMove.cs
@@ -33,15 +33,16 @@ public class CharacterMove : MonoBehaviour, IState<CharacterBase>
         // There's no way. Need to capture targetTranslation changes. (to check if being pushed)
         targetTranslation = _CharacterBase.targetTranslation;
 
-        float moveStep = _CharacterBase.curSpeed * Time.deltaTime;
         if (_CharacterBase.pushDirection != Vector3.zero)
         {
+            float moveStep = _CharacterBase.pushSpeed * Time.deltaTime;
             Vector3 currentTranslation = _CharacterBase.transform.position;
             Vector3 direction = (targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(direction * moveStep, Space.World);
         }
         else
         {
+            float moveStep = _CharacterBase.curSpeed * Time.deltaTime;
             _CharacterBase.transform.Translate(Vector3.forward * moveStep);
         }
     }
@@ -50,10 +51,11 @@ public class CharacterMove : MonoBehaviour, IState<CharacterBase>
         Vector3 currentTranslation = _CharacterBase.transform.position;
         if (Vector3.Distance(currentTranslation, targetTranslation) < 0.2f)
         {
-            _CharacterBase.transform.position = targetTranslation;
-            _CharacterBase.playerCurPos = _CharacterBase.transform.position;
-            _CharacterBase.doneAction = true;
+            _CharacterBase.transform.position = targetTranslation; 
+            _CharacterBase.playerCurPos = _CharacterBase.transform.position; 
             _CharacterBase.pushDirection = Vector3.zero;
+            _CharacterBase.pushSpeed = 0;
+            _CharacterBase.doneAction = true;
         }
     }
 }

--- a/Chronus/Assets/Scripts/Object/MovingObstacle.cs
+++ b/Chronus/Assets/Scripts/Object/MovingObstacle.cs
@@ -55,6 +55,7 @@ public class MovingObstacle : MonoBehaviour
         {   
             // If this is a block: going to push the player
             PlayerController.playerController.pushDirection = direction;
+            PlayerController.playerController.pushSpeed = moveSpeed;
             PlayerController.playerController.targetTranslation = targetPosition + direction * 2.0f;
             // Else, if this is a spear: just game over.
         }
@@ -65,6 +66,7 @@ public class MovingObstacle : MonoBehaviour
             {
                 // If this is a block: going to push the phantom
                 PhantomController.phantomController.pushDirection = direction;
+                PhantomController.phantomController.pushSpeed = moveSpeed;
                 PhantomController.phantomController.targetTranslation = targetPosition + direction * 2.0f;
                 // Else, if this is a spear: kill it.
             }

--- a/Chronus/Assets/Scripts/Object/MovingObstacle.cs
+++ b/Chronus/Assets/Scripts/Object/MovingObstacle.cs
@@ -61,7 +61,7 @@ public class MovingObstacle : MonoBehaviour
         }
         if (PhantomController.phantomController.isPhantomExisting)
         {
-            Vector3 phantomTargetPosition = PlayerController.playerController.targetTranslation;
+            Vector3 phantomTargetPosition = PhantomController.phantomController.targetTranslation;
             if (phantomTargetPosition == targetPosition)
             {
                 // If this is a block: going to push the phantom

--- a/Chronus/Assets/Scripts/TurnManager.cs
+++ b/Chronus/Assets/Scripts/TurnManager.cs
@@ -49,8 +49,6 @@ public class TurnManager : MonoBehaviour
     private void EndTurn()
     {
         CLOCK = false;
-        // turn++;
-        Debug.Log("turn: " + rewindTurnCount);
         player.positionIterator.Add((player.playerCurPos, player.playerCurRot));
         boxList.ForEach(box => box.SaveCurrentPos());
         obstacleList.ForEach(obstacle => obstacle.SaveCurrentPos());


### PR DESCRIPTION
- Idle로 있어서 장애물에 밀리는 경우, 밀린 뒤의 position이 아니라 밀리기 전 position이 저장되는 문제 
- MovingObstacle이 이동할 칸에서, 제자리에서 도는 경우 MovingObstacle에 의해 움직이지 않는 문제 

로직은 구현되어 있었는데, 판정이 제대로 되지 않았네요. 적당히 수정 완료했습니다.