### PR TITLE
F 025 - Fall implementation, some bug fixes, made Fall -> gameover condition

### DIFF
--- a/Chronus/Assets/Prefabs/Player/Player.prefab
+++ b/Chronus/Assets/Prefabs/Player/Player.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 965985751615319944}
   - component: {fileID: 8337172169193159353}
   - component: {fileID: 6567613761597493224}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: Player
   m_TagString: Player
   m_Icon: {fileID: 0}
@@ -90,7 +90,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4243777499992674637}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
@@ -103,13 +103,13 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4243777499992674637}
   serializedVersion: 2
-  m_Mass: 1
+  m_Mass: 0.1
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 116
   m_CollisionDetection: 0
 --- !u!114 &8394453472789530744
 MonoBehaviour:
@@ -138,8 +138,9 @@ MonoBehaviour:
   cHop: {fileID: 2144903796421854843}
   doneAction: 0
   isMoveComplete: 0
+  isFallComplete: 1
+  willDropDeath: 0
   isTimeRewinding: 0
-  maxTurn: 0
   listCommandLog: []
 --- !u!114 &2144903796421854843
 MonoBehaviour:
@@ -196,6 +197,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4484388044528181326}
     m_Modifications:
+    - target: {fileID: -8915588155710038175, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8817281787139273663, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8773252310586501240, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -251,6 +264,30 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8575541744930526652, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8443249762317997238, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8129981902651326082, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8107098940773874018, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8066607240106700906, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -7717048562890601862, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -7676081345994160130, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.z
@@ -348,6 +385,18 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.18068495
       objectReference: {fileID: 0}
+    - target: {fileID: -7059269839796486764, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -7008398741908099543, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -6991791607363565395, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -6195767925147098426, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.99999994
@@ -383,6 +432,10 @@ PrefabInstance:
     - target: {fileID: -6195767925147098426, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0.015611505
+      objectReference: {fileID: 0}
+    - target: {fileID: -6015112833935643493, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -5992991504558130705, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -460,6 +513,14 @@ PrefabInstance:
       propertyPath: m_LocalRotation.y
       value: 0.07113144
       objectReference: {fileID: 0}
+    - target: {fileID: -5568371526223589888, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -5248097321090173071, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -4577884709625885312, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.9999997
@@ -496,6 +557,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.08821502
       objectReference: {fileID: 0}
+    - target: {fileID: -4499546861416304452, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -4460312194309860335, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.99999994
@@ -523,6 +588,10 @@ PrefabInstance:
     - target: {fileID: -4460312194309860335, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: -1.3599535e-10
+      objectReference: {fileID: 0}
+    - target: {fileID: -4452961582658878267, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -4434611904129794949, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.z
@@ -556,6 +625,14 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.16939269
       objectReference: {fileID: 0}
+    - target: {fileID: -4400620307728828189, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -4309583319272899344, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -3742184730561344849, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.99999994
@@ -587,6 +664,22 @@ PrefabInstance:
     - target: {fileID: -3742184730561344849, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0.00000038964916
+      objectReference: {fileID: 0}
+    - target: {fileID: -3717842597802684491, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -3485968469395713393, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -3231315254066928005, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -3196511607817033700, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -3102552582028154646, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
@@ -635,6 +728,10 @@ PrefabInstance:
     - target: {fileID: -2787160266239161918, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.07268783
+      objectReference: {fileID: 0}
+    - target: {fileID: -2724273280286209912, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -2577548232221058511, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
@@ -692,6 +789,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.000000009208802
       objectReference: {fileID: 0}
+    - target: {fileID: -2513211967274183879, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -2484921068739079471, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.00000009645309
@@ -744,6 +845,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.000000024137641
       objectReference: {fileID: 0}
+    - target: {fileID: -2210227153719645374, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -2085578126549454084, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.y
       value: 0.9999999
@@ -776,6 +881,18 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.00000011102214
       objectReference: {fileID: 0}
+    - target: {fileID: -2050281603375591292, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -1969909474970374544, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -1527989900987323175, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -1390486835521303448, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.99999976
@@ -807,6 +924,10 @@ PrefabInstance:
     - target: {fileID: -1390486835521303448, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.2748509
+      objectReference: {fileID: 0}
+    - target: {fileID: -1247003664793356404, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -1199148658654603064, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -872,6 +993,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.055898238
       objectReference: {fileID: 0}
+    - target: {fileID: -1091378731155413656, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -1063094714816996356, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.w
       value: -0.00000009487393
@@ -887,6 +1012,10 @@ PrefabInstance:
     - target: {fileID: -1063094714816996356, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.70168114
+      objectReference: {fileID: 0}
+    - target: {fileID: -1020846484649783157, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -990486108452363053, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -912,6 +1041,14 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.0050838785
       objectReference: {fileID: 0}
+    - target: {fileID: -848414467943434479, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -554692284075223436, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: -249412701573662481, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.9999999
@@ -931,6 +1068,10 @@ PrefabInstance:
     - target: {fileID: -249412701573662481, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.022295097
+      objectReference: {fileID: 0}
+    - target: {fileID: 104833321916223943, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 224974431777948332, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
@@ -955,6 +1096,22 @@ PrefabInstance:
     - target: {fileID: 224974431777948332, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0.00000017496016
+      objectReference: {fileID: 0}
+    - target: {fileID: 516238177801192766, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 707234756790704755, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 776801713456813618, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 830330311924083556, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 837258337692304951, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
@@ -988,6 +1145,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: MainCharacter
       objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 987288110480692562, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 997421436769475321, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158650905580872576, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1254519071296059582, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 1446437931513171584, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 1
@@ -999,6 +1176,30 @@ PrefabInstance:
     - target: {fileID: 1446437931513171584, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.00012518853
+      objectReference: {fileID: 0}
+    - target: {fileID: 1703314629090314375, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2241609094476358648, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2252644987267293795, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2380213454641143697, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2461222609840879860, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2536794939087234241, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2540637281127044162, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -1023,6 +1224,10 @@ PrefabInstance:
     - target: {fileID: 2540637281127044162, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.z
       value: -2.188608e-10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2692789719295519672, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2912192487738833527, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -1051,6 +1256,10 @@ PrefabInstance:
     - target: {fileID: 2912192487738833527, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0.1504013
+      objectReference: {fileID: 0}
+    - target: {fileID: 3093236767782625722, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3632057545220354742, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.y
@@ -1084,6 +1293,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.01600493
       objectReference: {fileID: 0}
+    - target: {fileID: 3901343523633025107, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 3934799897103805087, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
       value: 2.8376234e-12
@@ -1103,6 +1316,10 @@ PrefabInstance:
     - target: {fileID: 3934799897103805087, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.000000073990456
+      objectReference: {fileID: 0}
+    - target: {fileID: 4022418020001282049, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4112148141255318219, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.y
@@ -1156,6 +1373,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.07268787
       objectReference: {fileID: 0}
+    - target: {fileID: 4277113655460474399, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4278838899149707192, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.0000001
@@ -1192,6 +1413,14 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.0019291984
       objectReference: {fileID: 0}
+    - target: {fileID: 4372015674166220162, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700188253002450632, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4714302972691477508, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.99999994
@@ -1216,6 +1445,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.12358282
       objectReference: {fileID: 0}
+    - target: {fileID: 5038076471040019463, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 5074512353664290214, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_AABB.m_Center.x
       value: 0.0000017265556
@@ -1235,6 +1468,10 @@ PrefabInstance:
     - target: {fileID: 5074512353664290214, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_AABB.m_Extent.z
       value: 0.0010763895
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111009395439158745, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5411002327701537827, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -1328,6 +1565,10 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: -0.009521621
       objectReference: {fileID: 0}
+    - target: {fileID: 5928925120025028895, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 6150659798612423583, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.9999998
@@ -1388,6 +1629,18 @@ PrefabInstance:
       propertyPath: m_LocalRotation.z
       value: 0.0000007945148
       objectReference: {fileID: 0}
+    - target: {fileID: 6572528712973372937, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6630736456800207645, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6695134767700572982, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 6706675697504825001, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.000029563958
@@ -1407,6 +1660,10 @@ PrefabInstance:
     - target: {fileID: 6706675697504825001, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0.0038053412
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745566415056585330, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7197526170521544438, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -1523,6 +1780,10 @@ PrefabInstance:
     - target: {fileID: 7566928282359292815, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_AABB.m_Extent.z
       value: 0.0025839526
+      objectReference: {fileID: 0}
+    - target: {fileID: 7571114085468202082, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7845628920942329695, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
@@ -1664,6 +1925,10 @@ PrefabInstance:
       propertyPath: m_AABB.m_Extent.z
       value: 0.0007709053
       objectReference: {fileID: 0}
+    - target: {fileID: 8513859187771203891, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 8780819399608896670, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.9999998
@@ -1699,6 +1964,10 @@ PrefabInstance:
     - target: {fileID: 8780819399608896670, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.75887334
+      objectReference: {fileID: 0}
+    - target: {fileID: 8823709575717323308, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 63265cb625fbb448d8ba619517ed69ac, type: 3}

--- a/Chronus/Assets/Prefabs/Stair.prefab
+++ b/Chronus/Assets/Prefabs/Stair.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 687862372756237922}
   m_Layer: 0
   m_Name: Stair
-  m_TagString: Untagged
+  m_TagString: FirstFloor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Chronus/Assets/Prefabs/Tile.prefab
+++ b/Chronus/Assets/Prefabs/Tile.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6488725769065331834}
   m_Layer: 0
   m_Name: Tile
-  m_TagString: Untagged
+  m_TagString: FirstFloor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Chronus/Assets/Prefabs/Wall.prefab
+++ b/Chronus/Assets/Prefabs/Wall.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6570811667170783643}
   m_Layer: 0
   m_Name: Wall
-  m_TagString: Untagged
+  m_TagString: FirstFloor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Chronus/Assets/Scenes/Field.unity
+++ b/Chronus/Assets/Scenes/Field.unity
@@ -1590,7 +1590,7 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
-  isFallComplete: 0
+  willDropDeath: 0
 --- !u!65 &445944869
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -4753,7 +4753,7 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
-  isFallComplete: 0
+  willDropDeath: 0
 --- !u!65 &1488847113
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -5414,7 +5414,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rewindTurnCount: 0
   CLOCK: 0
-  fallCLOCK: 0
   player: {fileID: 397731200}
   phantom: {fileID: 804359044}
   boxList: []
@@ -6733,13 +6732,165 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 110876039757952089, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 133038520871203769, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 159117530918064022, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 226210085685471294, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 236342304947742613, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 299392959794108813, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 302836658660156661, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 392314923907864995, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 435067315588192387, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 514746398981515444, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 633601123130303823, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 711057193082845177, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 770487806343294374, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 817013774521171590, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116985088418341632, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156316586134223466, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1173485830428187886, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1223934733300830035, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1276530742989688996, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1292514146048921919, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1826006229185608256, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1879035046070991037, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2224918407314182471, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2231958202562198865, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2277932104638024313, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 2417013240605120036, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_IsTrigger
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2482085806772772444, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2601188528485946237, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3146486338057623935, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3232495675218070067, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3296816152233645574, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3457659343214226774, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3627825747000534853, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3868444099603602648, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4093910735020581524, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4118078674449451718, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4170093655938827702, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4243777499992674637, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_Name
       value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 4243777499992674637, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4345145457806064839, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4484388044528181326, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_RootOrder
@@ -6785,6 +6936,102 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4714001593791504456, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4797376516583488882, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5195419677310875422, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5387832999346671159, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413030464862404288, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5483693819118897700, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532604334569534978, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726960952980210299, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5750614094286255119, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5917097440322603505, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5976627389150179802, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6010394237758435509, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6047035040858710526, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6108370651357542991, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6179630652731751630, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6679929680606190552, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6726003981048519387, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6763327715734951100, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937203254136931659, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7223589200793280030, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7486712634145527461, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664383956398333111, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7890248145708393027, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8045565568683317637, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 8394453472789530727, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_Mass
       value: 0.1
@@ -6800,6 +7047,30 @@ PrefabInstance:
     - target: {fileID: 8394453472789530727, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_IsKinematic
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8394771583721124075, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8554995491533644979, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8706417465563403252, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8849000239957820886, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9092347150128715695, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9160634844774654540, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Layer
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}

--- a/Chronus/Assets/Scenes/Field.unity
+++ b/Chronus/Assets/Scenes/Field.unity
@@ -773,7 +773,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 263794770735745872, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 263794770735745872, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -781,7 +781,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 263794770735745872, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -12.8
+      value: -15
       objectReference: {fileID: 0}
     - target: {fileID: 263794770735745872, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1590,6 +1590,7 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
+  isFallComplete: 1
   willDropDeath: 0
 --- !u!65 &445944869
 BoxCollider:
@@ -4753,6 +4754,7 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
+  isFallComplete: 1
   willDropDeath: 0
 --- !u!65 &1488847113
 BoxCollider:

--- a/Chronus/Assets/Scenes/Field.unity
+++ b/Chronus/Assets/Scenes/Field.unity
@@ -308,6 +308,76 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: df442a635c0d9b14baaf4ae6d5676ac6, type: 3}
+--- !u!1001 &123540947
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 69
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &123540948 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 123540947}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &140436868
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -507,6 +577,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tile
       objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
 --- !u!4 &192194965 stripped
@@ -518,6 +592,76 @@ Transform:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
   m_PrefabInstance: {fileID: 288072171}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &248483015
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 66
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &248483016 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 248483015}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &248649694
 GameObject:
@@ -677,6 +821,50 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+--- !u!114 &272630104 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3632663121590721122, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+  m_PrefabInstance: {fileID: 272630103}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: abe693de95a814942a04ea235b0b704b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &272630105 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2531181437950435812, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+  m_PrefabInstance: {fileID: 272630103}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f2543d0a56684f946a8ae90bd38438a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &272630106 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 753261232140372117, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+  m_PrefabInstance: {fileID: 272630103}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 310756e53545e7345b0027b8c50b0c0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &272630107 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6585836720761546417, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+  m_PrefabInstance: {fileID: 272630103}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d6abbc146afa994e8bc7da6d06b66d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &288072171
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1009,7 +1197,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
       propertyPath: m_TagString
-      value: Obstacle
+      value: FirstFloor
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
@@ -1278,6 +1466,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Stair (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
 --- !u!4 &390859237 stripped
@@ -1398,6 +1590,7 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
+  isFallComplete: 0
 --- !u!65 &445944869
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1419,7 +1612,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 445944867}
   serializedVersion: 2
-  m_Mass: 0.05
+  m_Mass: 0.1
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
@@ -1563,6 +1756,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
   m_PrefabInstance: {fileID: 460797523}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &463614595
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &463614596 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 463614595}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &486973858
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1632,6 +1895,146 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4636169671246262447, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
   m_PrefabInstance: {fileID: 486973858}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &514277027
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &514277028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 514277027}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &547906883
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &547906884 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 547906883}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &582318783
 PrefabInstance:
@@ -2532,6 +2935,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tile (6)
       objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
 --- !u!4 &803904771 stripped
@@ -2544,12 +2951,82 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8316886444689069388, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
   m_PrefabInstance: {fileID: 272630103}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: da563132313aba4428fe40137adb970a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &838210639
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &838210640 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 838210639}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &844742001
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2998,12 +3475,86 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tile (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
 --- !u!4 &1007551247 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4636169671246262447, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
   m_PrefabInstance: {fileID: 1007551246}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1086248059
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 72
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1086248060 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1086248059}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1091019158
 PrefabInstance:
@@ -3203,6 +3754,76 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
   m_PrefabInstance: {fileID: 1242975407}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1250083013
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 71
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1250083014 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1250083013}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1263368730
 PrefabInstance:
@@ -3454,6 +4075,20 @@ Transform:
   - {fileID: 2124306619}
   - {fileID: 803904771}
   - {fileID: 390859237}
+  - {fileID: 1632891713}
+  - {fileID: 248483016}
+  - {fileID: 1831763549}
+  - {fileID: 838210640}
+  - {fileID: 123540948}
+  - {fileID: 547906884}
+  - {fileID: 1250083014}
+  - {fileID: 1086248060}
+  - {fileID: 514277028}
+  - {fileID: 1671511099}
+  - {fileID: 463614596}
+  - {fileID: 1807134259}
+  - {fileID: 1683174681}
+  - {fileID: 1619791474}
   m_Father: {fileID: 1583243765}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3734,6 +4369,10 @@ PrefabInstance:
     - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
       propertyPath: m_Name
       value: Stair
+      objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
@@ -4093,6 +4732,7 @@ MonoBehaviour:
   turnCycle: 2
   moveSpeed: 7
   isMoveComplete: 0
+  isDependantOnSwitch: 0
 --- !u!1 &1488847111 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
@@ -4113,6 +4753,7 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
+  isFallComplete: 0
 --- !u!65 &1488847113
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -4134,7 +4775,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1488847111}
   serializedVersion: 2
-  m_Mass: 0.05
+  m_Mass: 0.1
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
@@ -4451,6 +5092,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
   m_PrefabInstance: {fileID: 1599703549}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1619791473
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1619791474 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1619791473}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1628523906
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4517,6 +5228,146 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4636169671246262447, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
   m_PrefabInstance: {fileID: 1628523906}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1632891712
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1632891713 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1632891712}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1671511098
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 74
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1671511099 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1671511098}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1673968260
 GameObject:
   m_ObjectHideFlags: 0
@@ -4563,12 +5414,83 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rewindTurnCount: 0
   CLOCK: 0
+  fallCLOCK: 0
   player: {fileID: 397731200}
   phantom: {fileID: 804359044}
   boxList: []
   buttonList: []
   leverList: []
   obstacleList: []
+--- !u!1001 &1683174680
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 77
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1683174681 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1683174680}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1700786446
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5179,6 +6101,146 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1001 &1807134258
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 76
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1807134259 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1807134258}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1831763548
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 67
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1831763549 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1831763548}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1847726920
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5337,6 +6399,7 @@ MonoBehaviour:
   turnCycle: 1
   moveSpeed: 7
   isMoveComplete: 0
+  isDependantOnSwitch: 0
 --- !u!1001 &1898124582
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5586,6 +6649,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Stair
       objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
 --- !u!4 &1936607660 stripped
@@ -5666,6 +6733,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2417013240605120036, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4243777499992674637, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_Name
       value: Player
@@ -5712,6 +6783,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4484388044528181326, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8394453472789530727, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Mass
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8394453472789530727, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_UseGravity
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8394453472789530727, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Constraints
+      value: 116
+      objectReference: {fileID: 0}
+    - target: {fileID: 8394453472789530727, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_IsKinematic
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -5793,6 +6880,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+--- !u!1 &1979967828 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4137369883225489573, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+  m_PrefabInstance: {fileID: 272630103}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1979967832
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
+  serializedVersion: 2
+  m_Mass: 0.1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0
 --- !u!1001 &1982184755
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5979,7 +7087,7 @@ MonoBehaviour:
   - target: {fileID: 400354074}
     isInitiallyActive: 0
   isPressed: 0
-  resetTurnCount: 2
+  resetTurnCount: 4
   isMoveComplete: 0
 --- !u!1 &2117464331 stripped
 GameObject:
@@ -6085,6 +7193,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Stair
       objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
 --- !u!4 &2120459597 stripped
@@ -6146,6 +7258,10 @@ PrefabInstance:
     - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
       propertyPath: m_Name
       value: Tile (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: FirstFloor
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -85,16 +85,20 @@ public abstract class CharacterBase : MonoBehaviour
                 sm.IsDoneAction();
                 if (doneAction) // next state in the state list
                 {
-                    listSeq++; // next index
                     doneAction = false;
-                    if (listSeq < listCurTurn.Count)
+                    if (listSeq >= 0)
                     {
-                        sm.SetState(listCurTurn[listSeq]);
-                    }
-                    else
-                    {
-                        sm.SetState(idle);
-                        //isMoveComplete = true;
+                        listSeq++; // next index
+                        if (listSeq < listCurTurn.Count)
+                        {
+                            sm.SetState(listCurTurn[listSeq]);
+                        }
+                        else
+                        {
+                            listSeq = -1; // no list update.
+                            sm.SetState(idle);
+                            //isMoveComplete = true;
+                        }
                     }
                 }
             }
@@ -102,7 +106,7 @@ public abstract class CharacterBase : MonoBehaviour
         }
         if ((TurnManager.turnManager.CLOCK || willDropDeath) && !isFallComplete)
         {
-            if (Physics.Raycast(playerCurPos, Vector3.down, out RaycastHit hit, rayDistance, layerMask))
+            if (Physics.Raycast(transform.position, Vector3.down, out RaycastHit hit, rayDistance, layerMask))
             {
                 // Tile detected, keep Y position constraint to keep the box stable
                 rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionY;
@@ -114,7 +118,7 @@ public abstract class CharacterBase : MonoBehaviour
                 }
                 else
                 {
-                    playerCurPos = transform.position; //update position.
+                    playerCurPos = transform.position; //update position after fall.
                     isFallComplete = true;
                     isMoveComplete = true; //all tasks done at this turn
                 }
@@ -135,8 +139,8 @@ public abstract class CharacterBase : MonoBehaviour
     public virtual void KillCharacter()  //gameover, initialize
     {
         rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionY;
-        willDropDeath = false;
-        isFallComplete = true;
+        willDropDeath = false; //already dead.
+        isFallComplete = true; //ended fall.
     }
 
     public void AdvanceFall()

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -32,6 +32,12 @@ public abstract class CharacterBase : MonoBehaviour
     protected IState<CharacterBase> idle, move, turn, hop;
     // index of state list
     protected int listSeq = 0;
+
+    protected float rayDistance = 1.0f;
+    protected float rayJumpInterval = 1.0f;
+    protected float maxFallHeight = 10.0f;
+    protected int layerMask = 1 << 0;
+
     // task of a state ended, need to jump to next state (next index of the state list)
     // can be changed from state's DoneAction func, through sender
     public bool doneAction = false; // for state machine

--- a/Chronus/Assets/Scripts/Character/CharacterHop.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterHop.cs
@@ -81,7 +81,9 @@ public class CharacterHop : MonoBehaviour, IState<CharacterBase>
     public void DoneAction(CharacterBase sender)
     {
         Vector3 currentTranslation = _CharacterBase.transform.position;
-        if (Vector3.Distance(currentTranslation, targetTranslation) < 0.3f)
+        float gap = Mathf.Sqrt((currentTranslation.x - _CharacterBase.playerCurPos.x) * (currentTranslation.x - _CharacterBase.playerCurPos.x) +
+            (currentTranslation.z - _CharacterBase.playerCurPos.z) * (currentTranslation.z - _CharacterBase.playerCurPos.z));
+        if (Vector3.Distance(currentTranslation, targetTranslation) < 0.1f || gap >= 2.0f)
         {
             _CharacterBase.transform.position = targetTranslation;
             _CharacterBase.playerCurPos = _CharacterBase.transform.position;

--- a/Chronus/Assets/Scripts/Character/CharacterIdle.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterIdle.cs
@@ -50,12 +50,13 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
             if (Vector3.Distance(currentTranslation, _CharacterBase.targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
             {
                 _CharacterBase.transform.position = _CharacterBase.targetTranslation;
-                _CharacterBase.playerCurPos = _CharacterBase.transform.position;
+                _CharacterBase.playerCurPos = _CharacterBase.transform.position; //update position.
                 _CharacterBase.pushDirection = Vector3.zero;
                 _CharacterBase.pushSpeed = 0;
                 _CharacterBase.doneAction = true;
-                _CharacterBase.isMoveComplete = true;
-                _CharacterBase.pushDirection = Vector3.zero;
+                //_CharacterBase.isMoveComplete = true;
+                //_CharacterBase.isFallComplete = false;
+                _CharacterBase.AdvanceFall();
             }
         }
         else if (_CharacterBase.isRidingBox)
@@ -72,7 +73,9 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
         else
         {
             _CharacterBase.doneAction = true;
-            _CharacterBase.isMoveComplete = true;
+            //_CharacterBase.isMoveComplete = true;
+            //_CharacterBase.isFallComplete = false;
+            _CharacterBase.AdvanceFall();
         }
     }
 }

--- a/Chronus/Assets/Scripts/Character/CharacterIdle.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterIdle.cs
@@ -39,7 +39,8 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
             Vector3 direction = (_CharacterBase.targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(direction * moveStep, Space.World);
         }
-
+        //need "fall" condition (maybe don't need that)
+        //game over by fell condition also.
     }
     public void DoneAction(CharacterBase sender)
     {
@@ -53,6 +54,8 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
                 _CharacterBase.pushDirection = Vector3.zero;
                 _CharacterBase.pushSpeed = 0;
                 _CharacterBase.doneAction = true;
+                _CharacterBase.isMoveComplete = true;
+                _CharacterBase.pushDirection = Vector3.zero;
             }
         }
         else if (_CharacterBase.isRidingBox)
@@ -69,6 +72,7 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
         else
         {
             _CharacterBase.doneAction = true;
+            _CharacterBase.isMoveComplete = true;
         }
     }
 }

--- a/Chronus/Assets/Scripts/Character/CharacterIdle.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterIdle.cs
@@ -54,9 +54,7 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
                 _CharacterBase.pushDirection = Vector3.zero;
                 _CharacterBase.pushSpeed = 0;
                 _CharacterBase.doneAction = true;
-                //_CharacterBase.isMoveComplete = true;
-                //_CharacterBase.isFallComplete = false;
-                _CharacterBase.AdvanceFall();
+                if (TurnManager.turnManager.CheckMovingObjectsMoveComplete()) _CharacterBase.AdvanceFall(); //wait for movingobstacles and boxes to move completely
             }
         }
         else if (_CharacterBase.isRidingBox)
@@ -73,9 +71,7 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
         else
         {
             _CharacterBase.doneAction = true;
-            //_CharacterBase.isMoveComplete = true;
-            //_CharacterBase.isFallComplete = false;
-            _CharacterBase.AdvanceFall();
+            if (TurnManager.turnManager.CheckMovingObjectsMoveComplete()) _CharacterBase.AdvanceFall(); //wait for movingobstacles and boxes to move completely
         }
     }
 }

--- a/Chronus/Assets/Scripts/Character/CharacterMove.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterMove.cs
@@ -49,7 +49,7 @@ public class CharacterMove : MonoBehaviour, IState<CharacterBase>
     public void DoneAction(CharacterBase sender)
     {
         Vector3 currentTranslation = _CharacterBase.transform.position;
-        if (Vector3.Distance(currentTranslation, targetTranslation) < 0.2f)
+        if (Vector3.Distance(currentTranslation, targetTranslation) < 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
         {
             _CharacterBase.transform.position = targetTranslation; 
             _CharacterBase.playerCurPos = _CharacterBase.transform.position; 

--- a/Chronus/Assets/Scripts/Character/PhantomController.cs
+++ b/Chronus/Assets/Scripts/Character/PhantomController.cs
@@ -47,6 +47,8 @@ public class PhantomController : CharacterBase
     protected override void Update() 
     {
         if (!isPhantomExisting) return;
+        //intercept by timerewinding: at TurnManager - EnterTimeRewind
+        //intercept by gameover: at PlayerController - KillCharacter
         base.Update();
     }
 
@@ -54,5 +56,11 @@ public class PhantomController : CharacterBase
     {
         gameObject.SetActive(false);
         isPhantomExisting = false;
+    }
+
+    public override void KillCharacter()
+    {
+        base.KillCharacter();
+        KillPhantom();
     }
 }

--- a/Chronus/Assets/Scripts/Character/PhantomController.cs
+++ b/Chronus/Assets/Scripts/Character/PhantomController.cs
@@ -37,8 +37,7 @@ public class PhantomController : CharacterBase
     {
         if (!commandIterator.HasNext()) 
         {
-            gameObject.SetActive(false);
-            isPhantomExisting = false;    
+            KillPhantom();
             return;
         }
         string nextCommand = commandIterator.Next();  // Get the next command
@@ -49,5 +48,11 @@ public class PhantomController : CharacterBase
     {
         if (!isPhantomExisting) return;
         base.Update();
+    }
+
+    public void KillPhantom()
+    {
+        gameObject.SetActive(false);
+        isPhantomExisting = false;
     }
 }

--- a/Chronus/Assets/Scripts/Character/PlayerController.cs
+++ b/Chronus/Assets/Scripts/Character/PlayerController.cs
@@ -152,7 +152,8 @@ public class PlayerController : CharacterBase
         TurnManager.turnManager.CLOCK = false;
         TurnManager.turnManager.ResetMoveComplete();
         TurnManager.turnManager.ResetFallComplete();
-        //Initialize function let's go
+        
+        //Initialize function let's go (in F-014 maybe)
     }
     
     

--- a/Chronus/Assets/Scripts/Character/PlayerController.cs
+++ b/Chronus/Assets/Scripts/Character/PlayerController.cs
@@ -160,7 +160,7 @@ public class PlayerController : CharacterBase
     // Functions for Time Rewind mode //
     private void ToggleTimeRewindMode()
     {
-        if (TurnManager.turnManager.CLOCK) return; // assuring that every action should be ended (during the turn)
+        if (TurnManager.turnManager.CLOCK || TurnManager.turnManager.fallCLOCK) return; // assuring that every action should be ended (during the turn)
 
         if (!isTimeRewinding) TurnManager.turnManager.EnterTimeRewind();
         else TurnManager.turnManager.LeaveTimeRewind();
@@ -168,7 +168,7 @@ public class PlayerController : CharacterBase
 
     private void HandleTimeRewindInput(string command)
     {
-        if (TurnManager.turnManager.CLOCK || !isTimeRewinding) return; // active only in time rewind mode
+        if (TurnManager.turnManager.CLOCK || TurnManager.turnManager.fallCLOCK || !isTimeRewinding) return; // active only in time rewind mode
         switch (command)
         {
             case "q": // go to the 1 turn past

--- a/Chronus/Assets/Scripts/Character/PlayerController.cs
+++ b/Chronus/Assets/Scripts/Character/PlayerController.cs
@@ -140,6 +140,22 @@ public class PlayerController : CharacterBase
         commandIterator = new TurnLogIterator<string>(listCommandLog);
         positionIterator = new TurnLogIterator<(Vector3, Quaternion)>(listPosLog);
     }
+    
+    public override void KillCharacter()
+    {
+        base.KillCharacter();
+        //intercept by GameOver
+        if (!PhantomController.phantomController.isFallComplete) PhantomController.phantomController.KillCharacter(); //intercept during fall
+        else PhantomController.phantomController.KillPhantom(); //just normal kill
+        TurnManager.turnManager.boxList.ForEach(box => box.KillBox());
+
+        TurnManager.turnManager.CLOCK = false;
+        TurnManager.turnManager.ResetMoveComplete();
+        TurnManager.turnManager.ResetFallComplete();
+        //Initialize function let's go
+    }
+    
+    
 
     // Update() is redundant, because doing same thing from CharacterBase
 
@@ -160,7 +176,7 @@ public class PlayerController : CharacterBase
     // Functions for Time Rewind mode //
     private void ToggleTimeRewindMode()
     {
-        if (TurnManager.turnManager.CLOCK || TurnManager.turnManager.fallCLOCK) return; // assuring that every action should be ended (during the turn)
+        if (TurnManager.turnManager.CLOCK || willDropDeath) return; // assuring that every action should be ended (during the turn)
 
         if (!isTimeRewinding) TurnManager.turnManager.EnterTimeRewind();
         else TurnManager.turnManager.LeaveTimeRewind();
@@ -168,7 +184,7 @@ public class PlayerController : CharacterBase
 
     private void HandleTimeRewindInput(string command)
     {
-        if (TurnManager.turnManager.CLOCK || TurnManager.turnManager.fallCLOCK || !isTimeRewinding) return; // active only in time rewind mode
+        if (TurnManager.turnManager.CLOCK || willDropDeath || !isTimeRewinding) return; // active only in time rewind mode
         switch (command)
         {
             case "q": // go to the 1 turn past

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -247,7 +247,7 @@ public class Box : MonoBehaviour
     }
     public void SaveCurrentPos()
     {
-        if (willDropDeath) //save before kill.
+        if (willDropDeath || !gameObject.activeSelf) //save before kill.
         {
             positionIterator.Add((Vector3.zero, false));
         }

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -94,6 +94,7 @@ public class Box : MonoBehaviour
         willDropDeath = false;
         isFallComplete = true;
         gameObject.SetActive(false);
+        if (TurnManager.turnManager.CLOCK && isWaitingToCheckFall) isMoveComplete = true;
         //some particle effect and sound effect
     }
     public void AdvanceFall() //can refactor with characterbase.advancefall()

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -13,6 +13,7 @@ public class Box : MonoBehaviour
     public bool isFallComplete = false;
     private bool isBeingPushed = false;
     public bool willDropDeath = false;
+    private bool isWaitingToCheckFall = false;
     private float rayJumpInterval = 1.0f;
     private float maxFallHeight = 10.0f;
     private int layerMask = (1 << 0) + (1 << 3); //detect default(0) and player(3) layer.
@@ -32,6 +33,11 @@ public class Box : MonoBehaviour
 
     private void Update()
     {
+        if (isWaitingToCheckFall)
+        {
+            if (TurnManager.turnManager.CheckMovingObstaclesMoveComplete()) AdvanceFall(); //wait for movingobstacles to move completely
+        }
+
         if (willDropDeath && PlayerController.playerController.isTimeRewinding) //intercept by timerewinding
         {
             KillBox();
@@ -72,8 +78,13 @@ public class Box : MonoBehaviour
         // if it has touched the ground, then isMoveComplete = true. 
     }
     public void AdvanceTurn()
-    {   
-        if (!isBeingPushed) AdvanceFall();
+    {
+        if (!isBeingPushed)
+        {
+            //AdvanceFall();
+            if (gameObject.activeSelf) isWaitingToCheckFall = true;  //wait.
+            else isMoveComplete = true;  //just pass
+        }
         isBeingPushed = false;
     }
 
@@ -87,6 +98,8 @@ public class Box : MonoBehaviour
     }
     public void AdvanceFall() //can refactor with characterbase.advancefall()
     {
+        if (isWaitingToCheckFall) isWaitingToCheckFall = false;
+
         if (!willDropDeath)
         {
             // If no tile is detected, allow the box to fall
@@ -188,7 +201,9 @@ public class Box : MonoBehaviour
         transform.position = targetPosition;
         //isMoveComplete = true;
         //isFallComplete = false;
-        AdvanceFall();
+
+        //AdvanceFall();
+        isWaitingToCheckFall = true; //wait.
 
         // Also, need to implement this: but has to be changed
 

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -10,6 +10,7 @@ public class Box : MonoBehaviour
     
     public TurnLogIterator<Vector3> positionIterator;
     public bool isMoveComplete = false;
+    public bool isFallComplete = false;
     private bool isBeingPushed = false;
     private void Start()
     {
@@ -27,27 +28,36 @@ public class Box : MonoBehaviour
 
     private void Update()
     {
-        // Demo falling code. need fix.
-        if (Physics.Raycast(transform.position, Vector3.down, out RaycastHit hit, checkDistance))
+        if (TurnManager.turnManager.fallCLOCK && !isFallComplete)
         {
-            if (hit.collider.CompareTag("GroundFloor") || hit.collider.CompareTag("FirstFloor"))
+            if (Physics.Raycast(transform.position, Vector3.down, out RaycastHit hit, checkDistance))
             {
-                // Tile detected, keep Y position constraint to keep the box stable
-                rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionY;
+                if (hit.collider.CompareTag("GroundFloor") || hit.collider.CompareTag("FirstFloor") || hit.collider.CompareTag("Box"))
+                {
+                    // Tile detected, keep Y position constraint to keep the box stable
+                    rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionY;
+                    transform.position = new Vector3(transform.position.x, Mathf.Ceil(transform.position.y) - 0.5f, transform.position.z);
+                    isFallComplete = true;
+                }
+            }
+            else
+            {
+                // If no tile is detected, allow the box to fall
+                rb.constraints = RigidbodyConstraints.FreezeRotation;
             }
         }
-        else
-        {
-            // If no tile is detected, allow the box to fall
-            rb.constraints = RigidbodyConstraints.FreezeRotation;
-        }
-
+        
         // There should be a code indicating:
         // if it has touched the ground, then isMoveComplete = true. 
     }
     public void AdvanceTurn()
     {   
         if (!isBeingPushed) isMoveComplete = true;
+        isBeingPushed = false;
+    }
+    public void AdvanceFall()
+    {
+        //check if void or not
     }
     public bool TryMove(Vector3 direction)
     {
@@ -56,7 +66,8 @@ public class Box : MonoBehaviour
             if (hit.collider.CompareTag("Obstacle") || // need "Obstacle" tag for all walls.
                 hit.collider.CompareTag("Lever") ||
                 hit.collider.CompareTag("MovingObstacle") ||
-                hit.collider.CompareTag("Wall"))
+                hit.collider.CompareTag("Wall") ||
+                hit.collider.CompareTag("Player"))
             {
                 isBeingPushed = false;
                 return false;

--- a/Chronus/Assets/Scripts/Object/MovingObstacle.cs
+++ b/Chronus/Assets/Scripts/Object/MovingObstacle.cs
@@ -14,7 +14,9 @@ public class MovingObstacle : MonoBehaviour
     // for time rewind
     private bool isVisible = false;
     public bool isMoveComplete = false;
-    public TurnLogIterator<Vector3> positionIterator;
+    public TurnLogIterator<(Vector3, bool, int)> positionIterator;
+
+    public bool isDependantOnSwitch = false;
 
     private void Start()
     {
@@ -24,15 +26,15 @@ public class MovingObstacle : MonoBehaviour
 
     public void InitializeLog() 
     {
-        var initialPositionLog = new List<Vector3> { transform.position };
-        positionIterator = new TurnLogIterator<Vector3>(initialPositionLog);
+        var initialPositionLog = new List<(Vector3, bool, int)> { (transform.position, isVisible, turnCount ) };
+        positionIterator = new TurnLogIterator<(Vector3, bool, int)>(initialPositionLog);
     }
 
     public void AdvanceTurn()
     {
-        turnCount++;
+        if (!isDependantOnSwitch) turnCount++; //count cycle by itself
         if (turnCount == turnCycle)
-        {   
+        {
             Invoke("Move", 0.2f);
             isVisible = !isVisible;
             turnCount = 0;
@@ -91,7 +93,7 @@ public class MovingObstacle : MonoBehaviour
 
     public void SaveCurrentPos()
     {
-        positionIterator.Add(transform.position);
+        positionIterator.Add((transform.position, isVisible, turnCount));
     }
     public void RemoveLog(int k)
     {
@@ -99,7 +101,9 @@ public class MovingObstacle : MonoBehaviour
     }
     public void RestoreState()
     {
-        transform.position = positionIterator.Current;
-        isVisible = transform.position != hiddenPosition;
+        var current = positionIterator.Current;
+        transform.position = current.Item1;
+        isVisible = current.Item2;
+        turnCount = current.Item3;
     }
 }

--- a/Chronus/Assets/Scripts/TurnManager.cs
+++ b/Chronus/Assets/Scripts/TurnManager.cs
@@ -80,6 +80,24 @@ public class TurnManager : MonoBehaviour
         );
     }
 
+    public bool CheckMovingObjectsMoveComplete()
+    // Check if moving obstacles and boxes of the current turn on the scene are complete.
+    //need for preventing player and phantom from not falling, staying on the air.
+    {
+        return (
+            boxList.All(box => box.isMoveComplete) &&
+            obstacleList.All(obstacle => obstacle.isMoveComplete)
+        );
+    }
+    public bool CheckMovingObstaclesMoveComplete()
+    // Check if moving obstacles and boxes of the current turn on the scene are complete.
+    //need for preventing player and phantom from not falling, staying on the air.
+    {
+        return (
+            obstacleList.All(obstacle => obstacle.isMoveComplete)
+        );
+    }
+
     public void ResetMoveComplete()
     {
         player.isMoveComplete = false;
@@ -143,6 +161,7 @@ public class TurnManager : MonoBehaviour
     {
         player.isTimeRewinding = true;
 
+        rewindTurnCount = 0; //always starts at 0.
         // kill already existing phantom, if not ended
         if (phantom.willDropDeath) phantom.KillCharacter(); //intercept during death fall
         else phantom.KillPhantom(); //just normal kill


### PR DESCRIPTION
# Fall implementation, some bug fixes, made Fall -> gameover condition
## Related Issue(s)
Link or reference any related issues or tickets.
## PR Description
낙하 구현)
플레이어, 분신, 박스가 클락 사이클 내에서 각각 본인 행동을 완료한 후,
움직이는 물체가 다 움직이길 기다린 후 (기다리지 않으면: 낙하 조건 체크 시에는 발밑에 있다가 그 후에 옮겨질 가능성 존재)
낙하 조건을 확인하고,
조건을 만족할 시 rigidbody의 gravity를 이용해 떨어집니다. (freeze position으로 on/off함)

낙사 구현)
길이 10의 raycast를 아래로 쬐어서 충돌 판정이 나지 않는다면, 낙사하는 조건이다.
(즉 아래에 발판이 없는 공허이거나, 발판이 있어도 높이 차이가 10 초과라면 낙사로 간주)
낙사하는 조건일 시 해당 bool 변수를 켜서
턴 사이클과 관련 없이 독립적으로 낙하를 수행하도록 한다. (플레이어 본인 제외)
= 특정 오브젝트가 낙사 조건 하에서 낙하 수행 시 플레이어는 독립적으로 조작이 가능하다. (박스 떨어지는 중에도 조작 가능)

낙사 시)
분신 - 사라진다.
박스 - SetActive(false) 상태가 된다.
박스의 로그에 좌표와 더불어 SetActive 상태를 결정하는 변수를 저장하도록 바꾸었다.
박스가 낙사조건 하에서 낙하 중일 때, 그리고 낙사한 상태일 때에도 계속 로그에 false 상태로 저장된다.
플레이어 - 게임오버이다.
게임오버 시 클락 OFF, 분신 삭제, 다른 오브젝트들의 행동 체크 관련 변수 초기화.
(그 후 시작지점으로 모든 오브젝트의 위치 및 상태정보 및 로그를 초기화한다.) - 이미 다른 branch에서 구현된 사항이라 비워두었습니다.

버그수정)
움직이는 벽의 로그 저장 시 움직일 턴 간격을 카운트하는 값도 저장
플레이어가 한 칸 움직일 때 종료 조건을 더 추가함 (gap이 한 칸 이상 늘어나면 종료하는 조건)
- 더 매끄러운 움직임을 위해서
- 렉이 걸리는 환경에서 게임을 구동할 때 무한루프로 빠지는 버그를 방지하기 위해서

Iterator 관련 코드 오류 수정
- 매 시간 되돌리기마다 리스트를 삭제할 범위를 지정하는 int 변수를 초기화해줌

### Changes Included
- [o] Added new feature(s)
- [o] Fixed identified bug(s)
- [o] Updated relevant documentation
### Screenshots (if UI changes were made)
slack에 올리는 영상으로 대체합니다
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [x] Manual testing has been performed to ensure the PR works as expected.
- [x] Code review comments have been addressed or clarified.
---
## Additional Comments
으아 다음 것 진짜 빨리 해보겠습니다 ㅜㅜ
linter.yml:
