### PR TITLE
F 026 (Ride on the box: player,phantom, and other boxes)

### DIFF
--- a/Chronus/Assets/Scenes/Field.unity
+++ b/Chronus/Assets/Scenes/Field.unity
@@ -671,6 +671,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Phantom
       objectReference: {fileID: 0}
+    - target: {fileID: 4137369883225489573, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
 --- !u!1001 &288072171
@@ -896,7 +900,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalPosition.y
@@ -904,7 +908,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1002,6 +1006,10 @@ PrefabInstance:
     - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
       propertyPath: m_Name
       value: Stair
+      objectReference: {fileID: 0}
+    - target: {fileID: 5007522419709582150, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
+      propertyPath: m_TagString
+      value: Obstacle
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1655884a7bd0227499fd8a20fae34d78, type: 3}
@@ -1326,7 +1334,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalRotation.w
@@ -2718,6 +2726,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c15bf34e68a32534590877db0498d978, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isPaused: 0
 --- !u!1001 &893312964
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5544,6 +5553,83 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+--- !u!1001 &1981548636
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_Name
+      value: boxA (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+      propertyPath: m_TagString
+      value: Box
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
 --- !u!1001 &1982184755
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5732,6 +5818,55 @@ MonoBehaviour:
   isPressed: 0
   resetTurnCount: 2
   isMoveComplete: 0
+--- !u!1 &2117464331 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
+  m_PrefabInstance: {fileID: 1981548636}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2117464332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2117464331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3817fa54d2d09b438c115d856401cce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveDistance: 2
+  checkDistance: 0.5
+  isMoveComplete: 0
+--- !u!65 &2117464333
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2117464331}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.02, y: 0.02, z: 0.02}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &2117464334
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2117464331}
+  serializedVersion: 2
+  m_Mass: 0.05
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0
 --- !u!1001 &2120459596
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -20,6 +20,7 @@ public abstract class CharacterBase : MonoBehaviour
 
     public Vector3 pushDirection = Vector3.zero; // to check if being pushed
     public float pushSpeed = 0;
+    public bool isRidingBox = false;
     private const float BLOCK_SIZE = 2.0f;
 
     // State management
@@ -108,7 +109,7 @@ public abstract class CharacterBase : MonoBehaviour
                 break;
             case "r":
                 listCurTurn = listStay;
-                targetTranslation = playerCurPos;
+                if (!isRidingBox) targetTranslation = playerCurPos;
                 StartAction();
                 return;
         }
@@ -127,9 +128,10 @@ public abstract class CharacterBase : MonoBehaviour
         if (curTurnAngle != 0.0f)
         {
             listCurTurn = listTurn;
-            targetTranslation = playerCurPos; // staying at the previous grid
+            targetTranslation = playerCurPos; // staying at the previous grid // because stuck at the wall
             StartAction();
         }
+        //do nothing, no turn update.
     }
 
     protected void TryToMoveToDirection()
@@ -142,7 +144,7 @@ public abstract class CharacterBase : MonoBehaviour
         Vector3 rayStart = transform.position + rayOffset;
 
         // First, check if there's an wall-like object to that target direction. 
-        if (Physics.Raycast(transform.position, targetDirection, out RaycastHit hit, BLOCK_SIZE))
+        if (Physics.Raycast(transform.position - new Vector3(0,0.1f,0), targetDirection, out RaycastHit hit, BLOCK_SIZE))
         {
             switch (hit.collider.tag)
             {
@@ -152,7 +154,6 @@ public abstract class CharacterBase : MonoBehaviour
                         if (lever.canToggleDirection == targetDirection)
                         {
                             lever.doPushLever = true;
-                            targetTranslation = playerCurPos; // because stuck at the wall
                             ChooseAndStartAction(listStay, listTurn);
                         }
                         else
@@ -203,8 +204,8 @@ public abstract class CharacterBase : MonoBehaviour
         }
         else // if there is no wall: then check if target position has floor
         {
-            Debug.DrawRay(rayStart, -transform.up * 2 * BLOCK_SIZE, Color.blue, 1.0f);
-            if (Physics.Raycast(rayStart, -transform.up, out RaycastHit hitGround, 2*BLOCK_SIZE))
+            Debug.DrawRay(rayStart, -transform.up * BLOCK_SIZE, Color.blue, 1.0f);
+            if (Physics.Raycast(rayStart, -transform.up, out RaycastHit hitGround, BLOCK_SIZE))
             {
                 GameObject floor = hitGround.collider.gameObject;
 

--- a/Chronus/Assets/Scripts/Character/CharacterIdle.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterIdle.cs
@@ -6,7 +6,6 @@ using UnityEngine.AI;
 public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
 {
     private CharacterBase _CharacterBase;
-    private Vector3 targetTranslation;
     // State Replace!
     public void OperateEnter(CharacterBase sender)
     {
@@ -28,18 +27,16 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
     {
         if (_CharacterBase.pushDirection != Vector3.zero) //obstacle push > box ride
         {
-            targetTranslation = _CharacterBase.targetTranslation;
             float moveStep = _CharacterBase.pushSpeed * Time.deltaTime;
             Vector3 currentTranslation = _CharacterBase.transform.position;
-            Vector3 direction = (targetTranslation - currentTranslation).normalized;
+            Vector3 direction = (_CharacterBase.targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(direction * moveStep, Space.World);
         }
         else if (_CharacterBase.isRidingBox)
         {
-            targetTranslation = _CharacterBase.targetTranslation;
             float moveStep = _CharacterBase.moveSpeedHor * Time.deltaTime;
             Vector3 currentTranslation = _CharacterBase.transform.position;
-            Vector3 direction = (targetTranslation - currentTranslation).normalized;
+            Vector3 direction = (_CharacterBase.targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(direction * moveStep, Space.World);
         }
 
@@ -49,9 +46,9 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
         if (_CharacterBase.pushDirection != Vector3.zero) //obstacle push > box ride
         {
             Vector3 currentTranslation = _CharacterBase.transform.position;
-            if (Vector3.Distance(currentTranslation, targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
+            if (Vector3.Distance(currentTranslation, _CharacterBase.targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
             {
-                _CharacterBase.transform.position = targetTranslation;
+                _CharacterBase.transform.position = _CharacterBase.targetTranslation;
                 _CharacterBase.playerCurPos = _CharacterBase.transform.position;
                 _CharacterBase.pushDirection = Vector3.zero;
                 _CharacterBase.pushSpeed = 0;
@@ -61,9 +58,9 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
         else if (_CharacterBase.isRidingBox)
         {
             Vector3 currentTranslation = _CharacterBase.transform.position;
-            if (Vector3.Distance(currentTranslation, targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
+            if (Vector3.Distance(currentTranslation, _CharacterBase.targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
             {
-                _CharacterBase.transform.position = targetTranslation;
+                _CharacterBase.transform.position = _CharacterBase.targetTranslation;
                 _CharacterBase.playerCurPos = _CharacterBase.transform.position;
                 _CharacterBase.isRidingBox = false;
                 _CharacterBase.doneAction = true;

--- a/Chronus/Assets/Scripts/Character/CharacterIdle.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterIdle.cs
@@ -26,7 +26,7 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
     // Always Do something when the current state is this state
     public void OperateUpdate(CharacterBase sender)
     {
-        if (_CharacterBase.pushDirection != Vector3.zero)
+        if (_CharacterBase.pushDirection != Vector3.zero) //obstacle push > box ride
         {
             targetTranslation = _CharacterBase.targetTranslation;
             float moveStep = _CharacterBase.pushSpeed * Time.deltaTime;
@@ -34,20 +34,38 @@ public class CharacterIdle : MonoBehaviour, IState<CharacterBase>
             Vector3 direction = (targetTranslation - currentTranslation).normalized;
             _CharacterBase.transform.Translate(direction * moveStep, Space.World);
         }
-        //need "fall" condition
-        //game over by fell condition also.
+        else if (_CharacterBase.isRidingBox)
+        {
+            targetTranslation = _CharacterBase.targetTranslation;
+            float moveStep = _CharacterBase.moveSpeedHor * Time.deltaTime;
+            Vector3 currentTranslation = _CharacterBase.transform.position;
+            Vector3 direction = (targetTranslation - currentTranslation).normalized;
+            _CharacterBase.transform.Translate(direction * moveStep, Space.World);
+        }
+
     }
     public void DoneAction(CharacterBase sender)
     {
-        if (_CharacterBase.pushDirection != Vector3.zero)
+        if (_CharacterBase.pushDirection != Vector3.zero) //obstacle push > box ride
         {
             Vector3 currentTranslation = _CharacterBase.transform.position;
-            if (Vector3.Distance(currentTranslation, targetTranslation) < 0.1f)
+            if (Vector3.Distance(currentTranslation, targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
             {
                 _CharacterBase.transform.position = targetTranslation;
                 _CharacterBase.playerCurPos = _CharacterBase.transform.position;
                 _CharacterBase.pushDirection = Vector3.zero;
                 _CharacterBase.pushSpeed = 0;
+                _CharacterBase.doneAction = true;
+            }
+        }
+        else if (_CharacterBase.isRidingBox)
+        {
+            Vector3 currentTranslation = _CharacterBase.transform.position;
+            if (Vector3.Distance(currentTranslation, targetTranslation) <= 0.1f || Vector3.Distance(currentTranslation, _CharacterBase.playerCurPos) >= 2.0f)
+            {
+                _CharacterBase.transform.position = targetTranslation;
+                _CharacterBase.playerCurPos = _CharacterBase.transform.position;
+                _CharacterBase.isRidingBox = false;
                 _CharacterBase.doneAction = true;
             }
         }

--- a/Chronus/Assets/Scripts/Character/PlayerController.cs
+++ b/Chronus/Assets/Scripts/Character/PlayerController.cs
@@ -54,6 +54,8 @@ public class TurnLogIterator<T>
 
     public int GetCurrentIndex() => currentIndex;
 
+    public T GetNext() => log[currentIndex + 1];
+
     public void Add(T item)
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
@@ -101,7 +103,7 @@ public class TurnLogIterator<T>
 public class PlayerController : CharacterBase
 {
     public static PlayerController playerController;
-    private string curKey = "r"; // command log(wasdr)
+    public string curKey = "r"; // command log(wasdr)
     public bool isTimeRewinding = false;
     // Iterators for logs
     public TurnLogIterator<string> commandIterator;

--- a/Chronus/Assets/Scripts/Object/MovingObstacle.cs
+++ b/Chronus/Assets/Scripts/Object/MovingObstacle.cs
@@ -79,7 +79,8 @@ public class MovingObstacle : MonoBehaviour
 
     private IEnumerator MoveObstacle(Vector3 targetPosition)
     {
-        while (Vector3.Distance(transform.position, targetPosition) > 0.01f)
+        Vector3 startPosition = transform.position;
+        while (Vector3.Distance(transform.position, targetPosition) > 0.01f && Vector3.Distance(transform.position, startPosition) < 2.0f)
         {
             transform.position = Vector3.MoveTowards(transform.position, targetPosition, moveSpeed * Time.deltaTime);
             yield return null;

--- a/Chronus/Assets/Scripts/TurnManager.cs
+++ b/Chronus/Assets/Scripts/TurnManager.cs
@@ -137,6 +137,8 @@ public class TurnManager : MonoBehaviour
         // kill already existing phantom, if not ended
         phantom.isPhantomExisting = false;
         phantom.gameObject.SetActive(false);
+
+        rewindTurnCount = 0;
     }
 
     public void LeaveTimeRewind()


### PR DESCRIPTION
# PR Title [Descriptive title summarizing the change]
## Related Issue(s)
F-026
## PR Description

박스가 밀릴 때 (이동하기로 결정했을 때)
올라탄 플레이어 혹은 분신의 커맨드를 감지해서 박스와 같이 움직일 지 말지를 결정합니다.
(플레이어는 이미 입력된 curKey를 받아오고,
분신은 commandorder 리스트의 이번 순서의 커맨드를 (실제 구현은 다음 인덱스의 것 (이걸 위해서 Iterator에 GetNext()함수(다음 인덱스의 값을 읽기만 하고 인덱스 변화는 안 함)를 새로 만들어놨습니다.) 읽어옵니다.)
가만히 있는 경우 (r) - 목표위치에 장애물이 없다면
박스와 같이 움직이며
다른 동작을 하는 경우 (wsad) 박스와 상관없이 본인의 행동을 수행합니다.
(그런데 움직이길 결정할 때 타겟 포지션을 바꾸는데,
코드 실행 순서 상 본체가 올라타는 경우는 문제가 없지만, 분신이 올라타는 경우는 타겟포지션이 바뀐 후에 분신의 인풋 매니징 함수가 실행되어 본인이 커맨드(r키이다)를 읽고 타겟 포지션을 다시 설정하기 때문에 = 타겟포지션이 초기화되기 때문에 이를 방지 하기 위해 상자에 올라타기로 결정한 경우에는 타겟포지션을 설정하지 않는것으로 수정했습니다.)



상자와 같이 이동하는 행동 수행은 CharacterIdle state에서 합니다. (벽에 밀리는 것과 거의 비슷한 코드입니다.)
여기서 두 행동 우선순위를 설정했습니다.
벽에 밀리기가 박스랑 같이 움직이기보다 우선적입니다. 둘 다 일어나는 상황이면 -> 벽에 밀리기만 실행됩니다.
(CharacterIdle에서 if(벽밀리기조건) elseif (박스랑같이움직이기조건)의 형태로 위계를 정해놨습니다.)



박스랑 같이 움직이는 속도 = 박스 움직이는 속도 = 플레이어 기본 속도로 통일했습니다. 변수를 실제로 CharacterBase 기본 속도에서부터 받아옵니다. (6.0f 입니다)



+박스를 겹쳐서 밑에서부터 위까지 한꺼번에 밀 수 있게 했습니다. (direction값을 공통으로 하여 연쇄적으로 TryMove를 실행합니다.)
상자 위에 상자가 올라가는 코너케이스를 고려하여 만든 기능이며, 이에 따라 발생하는 또 다른 예상되는 버그들도 추후 해결할 예정입니다.



+아직 미완성으로 남겨져있던 박스 스크립트의 advanceturn 함수 제대로 만들었습니다
안 밀리는 상황에서만 advanceturn에서 업데이트하고,
밀리는 상황은 가만히 있습니다. (이동이 끝나면 업데이트가 알아서 될 상황)



+벽 감지할 때 정중앙이 아니라 살짝 밑을 (-0.1f) 쬐도록 했습니다
박스 2개 사이로 레이케스트가 들어가니까 무작위로 아래 혹은 위가 밀립니다, 그래서 확정적으로 아래 것을 밀도록 y값을 살짝 조정했습니다.



+CharacterIdle의 private 변수 targetTranslation을 삭제하고 _CharacterBase의 원래 targetTranslation 값을 바로 사용하는 것으로 바꾸었습니다.
사실 이 변수가 있는 것도 가독성 때문인 것 같고, 없어도 코드 짜는데 전혀 문제가 없는 상황입니다. 그런데 현재 발견한 바로는 오히려 저 변수를 애매하게 사용한 것 때문에 버그가 발생했습니다. 기본적으로 Update() 사이클에서 state의 DoneAction이 항상 OperateUpdate보다 먼저 실행됩니다.
그런데 여기서 전자에는 targetTranslation을 갱신하는 (원본을 로컬 변수에 get하는) 과정이 없었고, 후자에는 있었어서
업데이트 전의 이전 위치와 비교를 하고, 바로 조건을 만족하여 스테이트를 끝내버린 탓에 OperateUpdate에 가지도 못하고 끝나버리는 일이 발생합니다.
이 부분을 해결했습니다. 물론 DoneAction에도 targetTranslation을 갱신하는 방법도 있었겠지만, 제 판단에서는 그냥 아예 없애고 이미 제대로 된 값을 가지고 있는 원본 변수 (_CharacterBase.targetTranslation)를 그대로 사용하는 것이 더 깔끔하게 보였습니다.



+ 혹시나 렉 심하게 걸릴 경우를 대비하여 '박스'와 '움직이는 벽'의 Inumerate 함수에 들어있는 이동 종료 조건에도 '시작지점과 현재지점의 거리가 한칸(2.0f) 이상'이라는 조건을 추가해놨습니다. (중요해요 진짜..)(물론 이 경우는 타겟을 향해서 다가가는 구조라 무한히 이동할 일은 없겠지만, 그래도 있는게 좋지 않을까 생각합니다 혹시나 렉 걸리면 무한히 진동하는 상황도 나오지 않을까요)



### Changes Included
- [o] Added new feature(s)
- [o] Fixed identified bug(s)
- [o] Updated relevant documentation
### Screenshots (if UI changes were made)
슬랙에 올린 영상으로 대체
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
화이팅