### PR TITLE
[F-011] complete, F-026-2(1 of 2), F-031(just for code), HopUnder limit: 1 -> 10

### DIFF
--- a/Chronus/Assets/Prefabs/Phantom.prefab
+++ b/Chronus/Assets/Prefabs/Phantom.prefab
@@ -92,7 +92,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Size: {x: 0.5, y: 1, z: 0.5}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &8316886444689069388
 MonoBehaviour:
@@ -115,14 +115,16 @@ MonoBehaviour:
   curHopDir: 1
   curTurnAngle: 0
   pushDirection: {x: 0, y: 0, z: 0}
+  pushSpeed: 0
+  isRidingBox: 0
   cIdle: {fileID: 753261232140372117}
   cMove: {fileID: 2531181437950435812}
   cTurn: {fileID: 3632663121590721122}
   cHop: {fileID: 6585836720761546417}
   doneAction: 0
   isMoveComplete: 0
-  listCommandOrder: []
-  order: 0
+  isFallComplete: 1
+  willDropDeath: 0
   isPhantomExisting: 0
 --- !u!114 &6585836720761546417
 MonoBehaviour:

--- a/Chronus/Assets/Prefabs/Player/Player.prefab
+++ b/Chronus/Assets/Prefabs/Player/Player.prefab
@@ -93,7 +93,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
+  m_Size: {x: 0.5, y: 1, z: 0.5}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &8394453472789530727
 Rigidbody:
@@ -132,6 +132,8 @@ MonoBehaviour:
   curHopDir: 1
   curTurnAngle: 0
   pushDirection: {x: 0, y: 0, z: 0}
+  pushSpeed: 0
+  isRidingBox: 0
   cIdle: {fileID: 965985751615319944}
   cMove: {fileID: 8337172169193159353}
   cTurn: {fileID: 6567613761597493224}
@@ -140,8 +142,8 @@ MonoBehaviour:
   isMoveComplete: 0
   isFallComplete: 1
   willDropDeath: 0
+  curKey: r
   isTimeRewinding: 0
-  listCommandLog: []
 --- !u!114 &2144903796421854843
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Chronus/Assets/Prefabs/Stair.prefab
+++ b/Chronus/Assets/Prefabs/Stair.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 687862372756237922}
   m_Layer: 0
   m_Name: Stair
-  m_TagString: FirstFloor
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Chronus/Assets/Prefabs/Tile.prefab
+++ b/Chronus/Assets/Prefabs/Tile.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6488725769065331834}
   m_Layer: 0
   m_Name: Tile
-  m_TagString: FirstFloor
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Chronus/Assets/Prefabs/Wall.prefab
+++ b/Chronus/Assets/Prefabs/Wall.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6570811667170783643}
   m_Layer: 0
   m_Name: Wall
-  m_TagString: FirstFloor
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Chronus/Assets/Scenes/Field.unity
+++ b/Chronus/Assets/Scenes/Field.unity
@@ -692,7 +692,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &256386383
 PrefabInstance:
@@ -821,50 +821,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
---- !u!114 &272630104 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3632663121590721122, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
-  m_PrefabInstance: {fileID: 272630103}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979967828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: abe693de95a814942a04ea235b0b704b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &272630105 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2531181437950435812, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
-  m_PrefabInstance: {fileID: 272630103}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979967828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f2543d0a56684f946a8ae90bd38438a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &272630106 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 753261232140372117, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
-  m_PrefabInstance: {fileID: 272630103}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979967828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 310756e53545e7345b0027b8c50b0c0f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &272630107 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6585836720761546417, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
-  m_PrefabInstance: {fileID: 272630103}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979967828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d6abbc146afa994e8bc7da6d06b66d6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &288072171
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1072,7 +1028,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalScale.x
@@ -2415,7 +2371,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6570811667170783644, guid: df442a635c0d9b14baaf4ae6d5676ac6, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 6570811667170783644, guid: df442a635c0d9b14baaf4ae6d5676ac6, type: 3}
       propertyPath: m_LocalScale.z
@@ -5958,6 +5914,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
   m_PrefabInstance: {fileID: 1773463945}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1807134258
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1327008366}
+    m_Modifications:
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_RootOrder
+      value: 76
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+      propertyPath: m_TagString
+      value: GroundFloor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+--- !u!4 &1807134259 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
+  m_PrefabInstance: {fileID: 1807134258}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1828245213
 GameObject:
   m_ObjectHideFlags: 0
@@ -6102,76 +6128,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!1001 &1807134258
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1327008366}
-    m_Modifications:
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_RootOrder
-      value: 76
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_Name
-      value: Tile
-      objectReference: {fileID: 0}
-    - target: {fileID: 6969041165458848855, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-      propertyPath: m_TagString
-      value: GroundFloor
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
---- !u!4 &1807134259 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4049557813592324753, guid: 15d5ef41fa4ec0040a6ff31c1fac50c7, type: 3}
-  m_PrefabInstance: {fileID: 1807134258}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1831763548
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7076,6 +7032,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+--- !u!1 &1979967828 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4137369883225489573, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+  m_PrefabInstance: {fileID: 272630103}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1979967832
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979967828}
+  serializedVersion: 2
+  m_Mass: 0.1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0
 --- !u!1001 &1981548636
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7085,7 +7062,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalScale.x
@@ -7101,7 +7078,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
       propertyPath: m_LocalPosition.y
@@ -7153,27 +7130,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0270982a7ba4ab24eb278822794059c8, type: 3}
---- !u!1 &1979967828 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4137369883225489573, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
-  m_PrefabInstance: {fileID: 272630103}
-  m_PrefabAsset: {fileID: 0}
---- !u!54 &1979967832
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979967828}
-  serializedVersion: 2
-  m_Mass: 0.1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 116
-  m_CollisionDetection: 0
 --- !u!1001 &1982184755
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7382,6 +7338,8 @@ MonoBehaviour:
   moveDistance: 2
   checkDistance: 0.5
   isMoveComplete: 0
+  isFallComplete: 0
+  willDropDeath: 0
 --- !u!65 &2117464333
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -7556,19 +7514,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8294636706162919895, guid: e5276887a87ed054395fc1de9f0a50c2, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 8294636706162919895, guid: e5276887a87ed054395fc1de9f0a50c2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8294636706162919895, guid: e5276887a87ed054395fc1de9f0a50c2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8294636706162919895, guid: e5276887a87ed054395fc1de9f0a50c2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 8294636706162919895, guid: e5276887a87ed054395fc1de9f0a50c2, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Chronus/Assets/Scenes/Field.unity
+++ b/Chronus/Assets/Scenes/Field.unity
@@ -819,6 +819,14 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7332264089347800436, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+      propertyPath: m_Size.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7332264089347800436, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
+      propertyPath: m_Size.z
+      value: 0.5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5cdc9edb7caf708458803e1bb1a4a1c1, type: 3}
 --- !u!1001 &288072171
@@ -6789,6 +6797,14 @@ PrefabInstance:
     - target: {fileID: 2277932104638024313, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_Layer
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2417013240605120036, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Size.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2417013240605120036, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
+      propertyPath: m_Size.z
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2417013240605120036, guid: d9719df6c7d7c4250b221bbf3f8599e4, type: 3}
       propertyPath: m_IsTrigger

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -151,6 +151,8 @@ public abstract class CharacterBase : MonoBehaviour
 
     public void AdvanceFall()
     {
+        //suffocated in a tile, wall, etc
+        
         if (!willDropDeath)
         {
             // If no tile is detected, allow the box to fall

--- a/Chronus/Assets/Scripts/Character/PhantomController.cs
+++ b/Chronus/Assets/Scripts/Character/PhantomController.cs
@@ -55,7 +55,7 @@ public class PhantomController : CharacterBase
     public void KillPhantom()
     {
         gameObject.SetActive(false);
-        isPhantomExisting = false;
+        isPhantomExisting = false; //deactivate.
     }
 
     public override void KillCharacter()

--- a/Chronus/Assets/Scripts/Character/PlayerController.cs
+++ b/Chronus/Assets/Scripts/Character/PlayerController.cs
@@ -140,20 +140,34 @@ public class PlayerController : CharacterBase
         commandIterator = new TurnLogIterator<string>(listCommandLog);
         positionIterator = new TurnLogIterator<(Vector3, Quaternion)>(listPosLog);
     }
-    
+
+    public void ResetToStart()
+    {
+        commandIterator.ResetToStart();
+        positionIterator.ResetToStart();
+        RestoreState();
+    }
+
+    private void GameOverAndReset()
+    {
+        //freeze y pos and bool variables of fall condition reset
+        if (!PhantomController.phantomController.isFallComplete) PhantomController.phantomController.KillCharacter(); //intercept during fall
+        else PhantomController.phantomController.KillPhantom(); //just normal kill
+        TurnManager.turnManager.boxList.ForEach(box => box.DropKillBox());
+
+        TurnManager.turnManager.CLOCK = false; //CLOCK off
+        //isMoveComplete reset
+        TurnManager.turnManager.ResetMoveComplete();
+        TurnManager.turnManager.ResetFallComplete();
+
+        //reset position or state & reset iterator
+        TurnManager.turnManager.ResetObjects();
+    }
+
     public override void KillCharacter()
     {
         base.KillCharacter();
-        //intercept by GameOver
-        if (!PhantomController.phantomController.isFallComplete) PhantomController.phantomController.KillCharacter(); //intercept during fall
-        else PhantomController.phantomController.KillPhantom(); //just normal kill
-        TurnManager.turnManager.boxList.ForEach(box => box.KillBox());
-
-        TurnManager.turnManager.CLOCK = false;
-        TurnManager.turnManager.ResetMoveComplete();
-        TurnManager.turnManager.ResetFallComplete();
-        
-        //Initialize function let's go (in F-014 maybe)
+        GameOverAndReset();
     }
     
     
@@ -222,5 +236,14 @@ public class PlayerController : CharacterBase
 
         commandIterator.RemoveLastK(k);
         positionIterator.RemoveLastK(k);
+    }
+
+    public void RestoreState()
+    {
+        (Vector3 position, Quaternion rotation) newTransform = positionIterator.Current;
+        transform.position = newTransform.position;
+        transform.rotation = newTransform.rotation;
+        playerCurPos = newTransform.position;
+        playerCurRot = newTransform.rotation;
     }
 }

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -31,6 +31,12 @@ public class Box : MonoBehaviour
         positionIterator = new TurnLogIterator<(Vector3, bool)>(initialPositionLog);
     }
 
+    public void ResetToStart()
+    {
+        positionIterator.ResetToStart();
+        RestoreState();
+    }
+
     private void Update()
     {
         if (isWaitingToCheckFall)
@@ -40,7 +46,7 @@ public class Box : MonoBehaviour
 
         if (willDropDeath && PlayerController.playerController.isTimeRewinding) //intercept by timerewinding
         {
-            KillBox();
+            DropKillBox();
             return;
         }
         //intercept by gameover: at PlayerController - KillCharacter
@@ -54,7 +60,7 @@ public class Box : MonoBehaviour
 
                 if (willDropDeath) //hit the ground hard -> Drop Death
                 {
-                    KillBox();
+                    DropKillBox();
                 }
                 else
                 {
@@ -68,7 +74,7 @@ public class Box : MonoBehaviour
                 {
                     if (transform.position.y < -maxFallHeight) //fall to the void -> Drop Death
                     {
-                        KillBox();
+                        DropKillBox();
                     }
                 }
             }
@@ -88,7 +94,7 @@ public class Box : MonoBehaviour
         isBeingPushed = false;
     }
 
-    public void KillBox()
+    public void DropKillBox()
     {
         rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionY;
         willDropDeath = false;
@@ -127,17 +133,10 @@ public class Box : MonoBehaviour
     }
     public bool TryMove(Vector3 direction)
     {
-        if (Physics.Raycast(transform.position, direction, out RaycastHit hit, moveDistance))
-        {
-            if (hit.collider.CompareTag("Obstacle") || // need "Obstacle" tag for all walls.
-                hit.collider.CompareTag("Lever") ||
-                hit.collider.CompareTag("MovingObstacle") ||
-                hit.collider.CompareTag("Wall") ||
-                hit.collider.CompareTag("Player"))
-            {
-                isBeingPushed = false;
-                return false;
-            }
+        if (Physics.Raycast(transform.position, direction, out RaycastHit hit, moveDistance, layerMask) || Physics.Raycast(transform.position + new Vector3(0, 0.3f, 0), direction, out RaycastHit hit1, moveDistance, layerMask))
+        { 
+            isBeingPushed = false;
+            return false;
         }
         
         if (Physics.Raycast(transform.position, Vector3.up, out RaycastHit hitUp, moveDistance/2)) //look up.

--- a/Chronus/Assets/Scripts/Object/Button.cs
+++ b/Chronus/Assets/Scripts/Object/Button.cs
@@ -42,6 +42,11 @@ public class Button : MonoBehaviour
         stateIterator = new TurnLogIterator<(Vector3, bool, int)>(initialState);
         commandIterator = new TurnLogIterator<string>(initialCommands);
     }
+    public void ResetToStart()
+    {
+        stateIterator.ResetToStart();
+        RestoreState();
+    }
 
     private void OnTriggerEnter(Collider other)
     {

--- a/Chronus/Assets/Scripts/Object/Laser.cs
+++ b/Chronus/Assets/Scripts/Object/Laser.cs
@@ -38,7 +38,14 @@ public class Laser : MonoBehaviour
             lineRenderer.SetPosition(1, hit.point);
             if (hit.collider.CompareTag("Player"))
             {
-                Debug.Log("Game Over!");
+                if (hit.collider.name == "Player")
+                {
+                    PlayerController.playerController.KillCharacter();
+                }
+                if (hit.collider.name == "Phantom")
+                {
+                    PhantomController.phantomController.KillCharacter();
+                }
             }
         }
         else

--- a/Chronus/Assets/Scripts/Object/Lever.cs
+++ b/Chronus/Assets/Scripts/Object/Lever.cs
@@ -38,6 +38,11 @@ public class Lever : MonoBehaviour
         stateIterator = new TurnLogIterator<(Quaternion, bool, Vector3)>(initialState);
         commandIterator = new TurnLogIterator<string>(initialCommands);
     }
+    public void ResetToStart()
+    {
+        stateIterator.ResetToStart();
+        RestoreState();
+    }
 
     public void AdvanceTurn()
     {

--- a/Chronus/Assets/Scripts/Object/MovingObstacle.cs
+++ b/Chronus/Assets/Scripts/Object/MovingObstacle.cs
@@ -29,6 +29,11 @@ public class MovingObstacle : MonoBehaviour
         var initialPositionLog = new List<(Vector3, bool, int)> { (transform.position, isVisible, turnCount ) };
         positionIterator = new TurnLogIterator<(Vector3, bool, int)>(initialPositionLog);
     }
+    public void ResetToStart()
+    {
+        positionIterator.ResetToStart();
+        RestoreState();
+    }
 
     public void AdvanceTurn()
     {

--- a/Chronus/Assets/Scripts/TurnManager.cs
+++ b/Chronus/Assets/Scripts/TurnManager.cs
@@ -155,6 +155,21 @@ public class TurnManager : MonoBehaviour
         }
     }
 
+    public void ResetObjects()
+    {
+        player.ResetToStart();
+        boxList.ForEach(box => box.ResetToStart());
+        leverList.ForEach(lever => lever.ResetToStart());
+        buttonList.ForEach(button => button.ResetToStart());
+        obstacleList.ForEach(obstacle => obstacle.ResetToStart());
+
+        player.InitializeLog();
+        boxList.ForEach(box => box.InitializeLog());
+        leverList.ForEach(lever => lever.InitializeLog());
+        buttonList.ForEach(button => button.InitializeLog());
+        obstacleList.ForEach(obstacle => obstacle.InitializeLog());
+    }
+
     // Functions for time rewind 
     public void EnterTimeRewind()
     // entering time rewind mode: make an empty phantom(actually, the player) in current position 
@@ -218,11 +233,11 @@ public class TurnManager : MonoBehaviour
         rewindTurnCount -= turnDelta;
 
         // Use iterator to navigate through position logs
-        (Vector3 position, Quaternion rotation) newTransform;
+        //(Vector3 position, Quaternion rotation) newTransform;
 
         if (turnDelta == -1 && player.positionIterator.HasPrevious())
         {
-            newTransform = player.positionIterator.Previous();
+            /*newTransform = */player.positionIterator.Previous();
             player.commandIterator.Previous();
 
             boxList.ForEach(box => box.positionIterator.Previous());
@@ -234,7 +249,7 @@ public class TurnManager : MonoBehaviour
         }
         else if (turnDelta == 1 && player.positionIterator.HasNext())
         {
-            newTransform = player.positionIterator.Next();
+            /*newTransform = */player.positionIterator.Next();
             player.commandIterator.Next();
             
             boxList.ForEach(box => box.positionIterator.Next());
@@ -251,10 +266,13 @@ public class TurnManager : MonoBehaviour
         }
 
         // Apply new position and rotation to the player
+        player.RestoreState();
+        /*
         player.gameObject.transform.position = newTransform.position;
         player.gameObject.transform.rotation = newTransform.rotation;
         player.playerCurPos = newTransform.position;
         player.playerCurRot = newTransform.rotation;
+        */
 
         // Restore object states based on the iterator's current position
         boxList.ForEach(box => box.RestoreState());

--- a/Chronus/ProjectSettings/TagManager.asset
+++ b/Chronus/ProjectSettings/TagManager.asset
@@ -13,6 +13,7 @@ TagManager:
   - MovingObstacle
   - GoalTile
   - StartTile
+  - Wall
   layers:
   - Default
   - TransparentFX
@@ -20,8 +21,8 @@ TagManager:
   - Player
   - Water
   - UI
-  - GroundFloor
-  - FirstFloor
+  - 
+  - 
   - 
   - 
   - 


### PR DESCRIPTION
# [F-011] complete, F-026-2(1 of 2), F-031(just for code), HopUnder limit: 1 -> 10
## Related Issue(s)
Link or reference any related issues or tickets.
## PR Description
F-011: 플레이어의 게임오버 (낙사, 레이저닿기) 조건 시 -> 모든 object의 Iterator 및 위치-상태 초기화
F-026-2: F-025,F-026 구현하면서 생긴 버그 2개 중 하나 해결: 낙사하는 박스 위에 올라타서 플레이어도 같이 떨어지는 버그
F-031의 일부: 박스가 타일을 감지하는 방식: 태그(x) 레이어마스크(o) 로 변경, 코드만 구현하고 아직 field에 있는 것들은 안 바꿈,
다만 prefab에 있는 tile, stair, wall의 tag를 Untagged로 설정해두긴 함
아래로 점프 가능한 최대 높이를 1에서 10(낙사 안 하는 최대 조건)으로 늘림 - hop state에서 바로 해당 위치로 뛰어내림

### Changes Included
- [o] Added new feature(s)
- [o] Fixed identified bug(s)
- [o] Updated relevant documentation
### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [x] Manual testing has been performed to ensure the PR works as expected.
- [x] Code review comments have been addressed or clarified.
---
## Additional Comments
Add any other comments or information that might be useful for the review process.
linter.yml:
