### PR TITLE
F-026-2 Box Stack -> Fall bug fix

### DIFF
--- a/Chronus/.idea/.idea.Chronus/.idea/.gitignore
+++ b/Chronus/.idea/.idea.Chronus/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.Chronus.iml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/Chronus/.idea/.idea.Chronus/.idea/indexLayout.xml
+++ b/Chronus/.idea/.idea.Chronus/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/Chronus/.idea/.idea.Chronus/.idea/vcs.xml
+++ b/Chronus/.idea/.idea.Chronus/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/Chronus/Assets/Prefabs/Objects/BoxA.prefab
+++ b/Chronus/Assets/Prefabs/Objects/BoxA.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6366156506602792641}
   - component: {fileID: 6366156506602792642}
   - component: {fileID: 6366156506602792643}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: BoxA
   m_TagString: Box
   m_Icon: {fileID: 0}
@@ -127,8 +127,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3817fa54d2d09b438c115d856401cce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  targetTranslation: {x: 0, y: 0, z: 0}
   moveDistance: 2
-  checkDistance: 0.5
   isMoveComplete: 0
   isFallComplete: 1
   willDropDeath: 0

--- a/Chronus/Assets/Prefabs/Objects/BoxAHalf.prefab
+++ b/Chronus/Assets/Prefabs/Objects/BoxAHalf.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2155180111105339445}
   - component: {fileID: 2155180111105339446}
   - component: {fileID: 2155180111105339447}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: BoxAHalf
   m_TagString: Box
   m_Icon: {fileID: 0}
@@ -127,6 +127,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3817fa54d2d09b438c115d856401cce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  targetTranslation: {x: 0, y: 0, z: 0}
   moveDistance: 2
   isMoveComplete: 0
   isFallComplete: 1

--- a/Chronus/Assets/Prefabs/Objects/BoxB.prefab
+++ b/Chronus/Assets/Prefabs/Objects/BoxB.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2889927929955507743}
   - component: {fileID: 2889927929955507742}
   - component: {fileID: 2889927929955507729}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: BoxB
   m_TagString: Box
   m_Icon: {fileID: 0}
@@ -101,7 +101,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 116
   m_CollisionDetection: 0
 --- !u!65 &2889927929955507742
 BoxCollider:
@@ -128,6 +128,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3817fa54d2d09b438c115d856401cce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  targetTranslation: {x: 0, y: 0, z: 0}
   moveDistance: 2
   isMoveComplete: 0
   isFallComplete: 1

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -56,6 +56,8 @@ public abstract class CharacterBase : MonoBehaviour
 
     protected virtual void Start()
     {
+        targetTranslation = transform.position;
+
         rb = gameObject.GetComponent<Rigidbody>();
         rb.useGravity = true;
         rb.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionY;

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -289,7 +289,7 @@ public abstract class CharacterBase : MonoBehaviour
                             RotateInPlace();
                             break;
                         }
-                        if (box.TryMove(targetDirection))
+                        if (box.TryMove(targetDirection, 0))
                         {
                             ChooseAndStartAction(listMoveForward, listMoveSideRear);
                         }

--- a/Chronus/Assets/Scripts/Character/CharacterBase.cs
+++ b/Chronus/Assets/Scripts/Character/CharacterBase.cs
@@ -37,7 +37,7 @@ public abstract class CharacterBase : MonoBehaviour
     protected float rayDistance = 1.0f;
     protected float rayJumpInterval = 1.0f;
     protected float maxFallHeight = 10.0f;
-    protected int layerMask = (1 << 0) | (1 << 6); //default, lever
+    protected int layerMask = (1 << 0) | (1 << 6) | (1 << 8); //default, lever, box
 
     // task of a state ended, need to jump to next state (next index of the state list)
     // can be changed from state's DoneAction func, through sender

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -19,7 +19,8 @@ public class Box : MonoBehaviour
 
     private float rayJumpInterval = 1.0f;
     private float maxFallHeight = 10.0f;
-    private int layerMask = (1 << 0) | (1 << 3) | (1 << 6); //detect default(0), player(3), and lever(6) layer.
+    private int layerMask = (1 << 0) | (1 << 3) | (1 << 6) | (1 << 8); //detect default(0), player(3), lever(6) and box(8) layer.
+    private int layerMaskFall = (1 << 0) | (1 << 3) | (1 << 6); //don't detect other boxes.
     private void Start()
     {
         targetTranslation = transform.position;

--- a/Chronus/Assets/Scripts/Object/Box.cs
+++ b/Chronus/Assets/Scripts/Object/Box.cs
@@ -198,6 +198,7 @@ public class Box : MonoBehaviour
 
     public void CheckChainFall(bool doFall, float layer) //Recursion.
     {
+        if (isBeingPushed) return; //if locked - no CheckChainFall.(first box, calls this function only when !isBeingPushed, no problem ///but next boxes, can be Locked by isBeingPushed)
         if (Physics.Raycast(transform.position, Vector3.up, out RaycastHit hitUp, checkDistance + moveDistance / 4, 1<<8))
         {
             Box box = hitUp.collider.gameObject.GetComponent<Box>();

--- a/Chronus/Assets/Scripts/Object/Laser.cs
+++ b/Chronus/Assets/Scripts/Object/Laser.cs
@@ -13,7 +13,7 @@ public class Laser : MonoBehaviour
         lineRenderer.positionCount = 2; // start and end point
         lineRenderer.startWidth = 0.1f;
         lineRenderer.endWidth = 0.1f; // 0.05f;
-        layerMask = (1 << 0) | (1 << 3) | (1 << 7); //default and LeverStick
+        layerMask = (1 << 0) | (1 << 3) | (1 << 7) | (1 << 8); //default and LeverStick
     }
 
     public void ToggleLaser()

--- a/Chronus/Assets/Scripts/Object/MovingObstacle.cs
+++ b/Chronus/Assets/Scripts/Object/MovingObstacle.cs
@@ -62,23 +62,33 @@ public class MovingObstacle : MonoBehaviour
         direction = (targetPosition - transform.position).normalized;
         // first, check if the target position overlaps with player's target position.
         Vector3 playerTargetPosition = PlayerController.playerController.targetTranslation;
-        if (playerTargetPosition == targetPosition)
+        if (playerTargetPosition.x == targetPosition.x && playerTargetPosition.z == targetPosition.z &&
+            (playerTargetPosition.y >= targetPosition.y - 1 && playerTargetPosition.y <= targetPosition.y + 1))
         {   
             // If this is a block: going to push the player
             PlayerController.playerController.pushDirection = direction;
             PlayerController.playerController.pushSpeed = moveSpeed;
-            PlayerController.playerController.targetTranslation = targetPosition + direction * 2;
+            PlayerController.playerController.targetTranslation = 
+                new Vector3(
+                targetPosition.x + direction.x * 2,
+                PlayerController.playerController.targetTranslation.y, 
+                targetPosition.z + direction.z * 2);
             // Else, if this is a spear: just game over.
         }
         if (PhantomController.phantomController.isPhantomExisting)
         {
             Vector3 phantomTargetPosition = PhantomController.phantomController.targetTranslation;
-            if (phantomTargetPosition == targetPosition)
+            if (phantomTargetPosition.x == targetPosition.x && phantomTargetPosition.z == targetPosition.z &&
+                (phantomTargetPosition.y >= targetPosition.y - 1 && phantomTargetPosition.y <= targetPosition.y + 1))
             {
                 // If this is a block: going to push the phantom
                 PhantomController.phantomController.pushDirection = direction;
                 PhantomController.phantomController.pushSpeed = moveSpeed;
-                PhantomController.phantomController.targetTranslation = targetPosition + direction * 2;
+                PhantomController.phantomController.targetTranslation =
+                    new Vector3(
+                    targetPosition.x + direction.x * 2,
+                    PhantomController.phantomController.targetTranslation.y,
+                    targetPosition.z + direction.z * 2);
                 // Else, if this is a spear: kill it.
             }
         }

--- a/Chronus/Assets/Scripts/Testing.meta
+++ b/Chronus/Assets/Scripts/Testing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c787f08fbea6344dfb6881358334e6a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs
+++ b/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using UnityEngine;
+
+public class InputManagerTesting : MonoBehaviour
+{
+    private InputManager inputManager;
+
+    private void Start()
+    {
+        inputManager = InputManager.inputManager;
+        if (inputManager == null)
+        {
+            return;
+        }
+
+        StartCoroutine(TestCornerCase());
+    }
+
+    private IEnumerator TestCornerCase()
+    {
+        inputManager.OnMovementControl += LogAction;
+        inputManager.OnTimeRewindControl += LogAction;
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnMovementControl?.Invoke("d"); 
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnMovementControl?.Invoke("w"); 
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnMovementControl?.Invoke("w"); 
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnMovementControl?.Invoke("a"); 
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnMovementControl?.Invoke("s"); 
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnTimeRewindModeToggle?.Invoke();
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnTimeRewindModeToggle?.Invoke();
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnMovementControl?.Invoke("a");
+        yield return new WaitForSeconds(2);
+
+        inputManager.OnMovementControl -= LogAction;
+        inputManager.OnTimeRewindControl -= LogAction;
+
+        Debug.Log("Test completed successfully.");
+    }
+    
+    private void LogAction(string input)
+    {
+        Debug.Log($"Action Invoked: {input}");
+    }
+}

--- a/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs
+++ b/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 public class InputManagerTesting : MonoBehaviour
 {
     private InputManager inputManager;
+    
+    public bool case1 = false;
+    public bool case2 = false;
+    public bool case3 = false;
 
     private void Start()
     {
@@ -13,13 +17,74 @@ public class InputManagerTesting : MonoBehaviour
             return;
         }
 
-        StartCoroutine(TestCornerCase());
+        StartCoroutine(RunTests());
     }
-
-    private IEnumerator TestCornerCase()
+    
+    private IEnumerator RunTests()
     {
         inputManager.OnMovementControl += LogAction;
         inputManager.OnTimeRewindControl += LogAction;
+
+        if (case1)
+        {
+            yield return Case1();
+        }
+
+        if (case2)
+        {
+            yield return Case2();
+        }
+
+        if (case3)
+        {
+            yield return Case3();
+        }
+
+        inputManager.OnMovementControl -= LogAction;
+        inputManager.OnTimeRewindControl -= LogAction;
+
+        Debug.Log("All selected tests completed successfully.");
+    }
+
+    private IEnumerator Case1()
+    {
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnMovementControl?.Invoke("d"); 
+        yield return new WaitForSeconds(1);
+
+        inputManager.OnMovementControl?.Invoke("w"); 
+        yield return new WaitForSeconds(1);
+
+        inputManager.OnMovementControl?.Invoke("a"); 
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindModeToggle?.Invoke();
+        yield return new WaitForSeconds(1);
+
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindModeToggle?.Invoke();
+        yield return new WaitForSeconds(1);
+
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnMovementControl?.Invoke("w");
+        yield return new WaitForSeconds(1);
+    }
+    private IEnumerator Case2()
+    {
         yield return new WaitForSeconds(2);
         
         inputManager.OnMovementControl?.Invoke("d"); 
@@ -66,11 +131,53 @@ public class InputManagerTesting : MonoBehaviour
         
         inputManager.OnMovementControl?.Invoke("a");
         yield return new WaitForSeconds(1);
+    }
+    
+    private IEnumerator Case3()
+    {
+        yield return new WaitForSeconds(2);
+        
+        inputManager.OnMovementControl?.Invoke("d"); 
+        yield return new WaitForSeconds(1);
 
-        inputManager.OnMovementControl -= LogAction;
-        inputManager.OnTimeRewindControl -= LogAction;
+        inputManager.OnMovementControl?.Invoke("w"); 
+        yield return new WaitForSeconds(1);
 
-        Debug.Log("Test completed successfully.");
+        inputManager.OnMovementControl?.Invoke("w"); 
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnMovementControl?.Invoke("a"); 
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindModeToggle?.Invoke();
+        yield return new WaitForSeconds(1);
+
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindControl?.Invoke("q");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnTimeRewindModeToggle?.Invoke();
+        yield return new WaitForSeconds(1);
+
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnMovementControl?.Invoke("r");
+        yield return new WaitForSeconds(1);
+        
+        inputManager.OnMovementControl?.Invoke("w");
+        yield return new WaitForSeconds(1);
     }
     
     private void LogAction(string input)

--- a/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs
+++ b/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs
@@ -23,49 +23,49 @@ public class InputManagerTesting : MonoBehaviour
         yield return new WaitForSeconds(2);
         
         inputManager.OnMovementControl?.Invoke("d"); 
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnMovementControl?.Invoke("w"); 
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnMovementControl?.Invoke("w"); 
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnMovementControl?.Invoke("a"); 
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnMovementControl?.Invoke("s"); 
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnTimeRewindModeToggle?.Invoke();
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnTimeRewindControl?.Invoke("q");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnTimeRewindControl?.Invoke("q");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnTimeRewindControl?.Invoke("q");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnTimeRewindControl?.Invoke("q");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnTimeRewindModeToggle?.Invoke();
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnMovementControl?.Invoke("r");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnMovementControl?.Invoke("r");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnMovementControl?.Invoke("r");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
         
         inputManager.OnMovementControl?.Invoke("a");
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(1);
 
         inputManager.OnMovementControl -= LogAction;
         inputManager.OnTimeRewindControl -= LogAction;

--- a/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs.meta
+++ b/Chronus/Assets/Scripts/Testing/InputManagerTesting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 193d659822e2f4b29ac0cb530aacdaad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Chronus/ProjectSettings/TagManager.asset
+++ b/Chronus/ProjectSettings/TagManager.asset
@@ -23,7 +23,7 @@ TagManager:
   - UI
   - Lever
   - LeverStick
-  - 
+  - Box
   - 
   - 
   - 


### PR DESCRIPTION
# PR Title Box Stack -> Fall bug fix
## Related Issue(s)
F-026-2
## PR Description
F-026 박스 올라타기의 버그를 수정한 버전. (박스 위에 플레이어, 분신, 그리고 또 다른 박스가 올라타서 같이 밀리는 기능)
박스 여러 개를 위로 쌓았을 때 한꺼번에 낙하 가능하도록 구현함
F-035에서 구현했던 코너 케이스도 잘 작동하는 것 확인
높이 차를 나눠서 동시에 다른 방향으로 밀어도 제대로 작동하는 것 확인

구현 방법)
박스의 레이어를 8번으로 설정 (타일, 벽 등의 레이어(0번)와 다름), 스크립트 및 프리팹에 수정사항 반영함.
각 박스마다 상대적인 높이 값을 지님(boxLayer), 초기값 0, 맨 밑에 있거나 캐릭터에게 밀리면 초기값으로 설정됨.
다른 박스에게 신호를 받으면 (재귀함수) 가장 밑의 박스가 있는 바닥으로부터의 높이만큼의 값으로 갱신
밀려서 낙하할 때는 레이케스트를 자기 boxLayer 값만큼 더 길게 해서 박스 높이 차이 만큼만 낙하함 (장대로 걷는 것에 비유해서 생각하시면 쉽습니다.)
이 때 8번(박스) 레이어를 제외하고 감지하기에 밑에 있는 박스를 무시하고 레이캐스트를 계산함.
안 밀리는 경우에도 만약 땅이 꺼져서 (스위치 조작 -> 타일 off) 떨어져야 한다면
젤 밑의 박스가 위의 박스에게 신호를 보내서 (재귀함수) 같이 낙하하도록 함

F-035 연계 내용 설명)
박스 뭉치에 대해서도 F-035에서 구현한 코너 케이스가 잘 동작하는 것을 확인
본체와 분신이 높이 차를 두고 서로 다른 방향으로 박스 뭉치를 밀 때, 본체가 위쪽을 밀면 따로 밀어지고 분신은 그러지 못하는 이유: 
본체가 처음 상자를 밀게 되고, 그 처음 밀리는 박스의 boxLayer 값이 0으로 초기화됨, 그 박스를 기준으로 그 위의 박스가 따라서 떨어짐
무엇보다 F-035에서 isBeingPushed로 각 박스 당 한 번씩만 trymove를 하도록 lock을 걸어놔서 아래에서부터 올라오는 신호가 (재귀함수를 통해) 막히게 됨
반대로 분신이 위쪽을 밀면 본체가 우선 TryMove()를 실행하고 그에 따라 위에 있는 박스 전부가 TryMove()를 이미 실행했기에 분신이 위 부분을 가로채지 못함

### Changes Included
- [o] Added new feature(s)
- [o] Fixed identified bug(s)
- [o] Updated relevant documentation
### Screenshots (if UI changes were made)
슬랙 영상 대체
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
Add any other comments or information that might be useful for the review process.
linter.yml:
